### PR TITLE
Added support for retrieving the data from a data store

### DIFF
--- a/capabilities-common/src/main/java/ai/wanaku/capabilities/sdk/common/exceptions/WanakuWebException.java
+++ b/capabilities-common/src/main/java/ai/wanaku/capabilities/sdk/common/exceptions/WanakuWebException.java
@@ -1,0 +1,82 @@
+package ai.wanaku.capabilities.sdk.common.exceptions;
+
+import ai.wanaku.api.exceptions.WanakuException;
+
+/**
+ * Exception thrown when web-related operations fail in the Wanaku capabilities SDK.
+ * <p>
+ * This exception is used to indicate failures in HTTP/web communications, including
+ * network errors, HTTP errors, or other web-related issues that occur during
+ * capability operations. It captures the HTTP status code associated with the failure.
+ * </p>
+ */
+public class WanakuWebException extends WanakuException {
+    private final int statusCode;
+
+    /**
+     * Constructs a new WanakuWebException with the specified HTTP status code.
+     *
+     * @param statusCode the HTTP status code associated with this exception
+     */
+    public WanakuWebException(int statusCode) {
+        this.statusCode = statusCode;
+    }
+
+    /**
+     * Constructs a new WanakuWebException with the specified detail message and HTTP status code.
+     *
+     * @param message the detail message explaining the reason for the exception
+     * @param statusCode the HTTP status code associated with this exception
+     */
+    public WanakuWebException(String message, int statusCode) {
+        super(message);
+        this.statusCode = statusCode;
+    }
+
+    /**
+     * Constructs a new WanakuWebException with the specified detail message, cause, and HTTP status code.
+     *
+     * @param message the detail message explaining the reason for the exception
+     * @param cause the underlying cause of this exception
+     * @param statusCode the HTTP status code associated with this exception
+     */
+    public WanakuWebException(String message, Throwable cause, int statusCode) {
+        super(message, cause);
+        this.statusCode = statusCode;
+    }
+
+    /**
+     * Constructs a new WanakuWebException with the specified cause and HTTP status code.
+     *
+     * @param cause the underlying cause of this exception
+     * @param statusCode the HTTP status code associated with this exception
+     */
+    public WanakuWebException(Throwable cause, int statusCode) {
+        super(cause);
+        this.statusCode = statusCode;
+    }
+
+    /**
+     * Constructs a new WanakuWebException with the specified detail message, cause,
+     * suppression enabled or disabled, writable stack trace enabled or disabled, and HTTP status code.
+     *
+     * @param message the detail message explaining the reason for the exception
+     * @param cause the underlying cause of this exception
+     * @param enableSuppression whether or not suppression is enabled or disabled
+     * @param writableStackTrace whether or not the stack trace should be writable
+     * @param statusCode the HTTP status code associated with this exception
+     */
+    public WanakuWebException(String message, Throwable cause, boolean enableSuppression, boolean writableStackTrace, int statusCode) {
+        super(message, cause, enableSuppression, writableStackTrace);
+        this.statusCode = statusCode;
+    }
+
+    /**
+     * Returns the HTTP status code associated with this exception.
+     *
+     * @return the HTTP status code
+     */
+    public int getStatusCode() {
+        return statusCode;
+    }
+}

--- a/capabilities-discovery/src/main/java/ai/wanaku/capabilities/sdk/discovery/DiscoveryLogCallback.java
+++ b/capabilities-discovery/src/main/java/ai/wanaku/capabilities/sdk/discovery/DiscoveryLogCallback.java
@@ -1,0 +1,32 @@
+package ai.wanaku.capabilities.sdk.discovery;
+
+import ai.wanaku.api.discovery.DiscoveryCallback;
+import ai.wanaku.api.discovery.RegistrationManager;
+import ai.wanaku.api.types.providers.ServiceTarget;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+class DiscoveryLogCallback implements DiscoveryCallback {
+    private static final Logger LOG = LoggerFactory.getLogger(DiscoveryLogCallback.class);
+
+    @Override
+    public void onPing(RegistrationManager manager, ServiceTarget target, int status) {
+        if (status != 200) {
+            LOG.warn("Pinging router failed with status {}", status);
+        } else {
+            LOG.trace("Pinging router completed successfully");
+        }
+    }
+
+    @Override
+    public void onRegistration(RegistrationManager manager, ServiceTarget target) {
+        LOG.debug("The service {} successfully registered with ID {}.", target.getService(), target.getId());
+    }
+
+    @Override
+    public void onDeregistration(RegistrationManager manager, ServiceTarget target, int status) {
+        if (status != 200) {
+            LOG.warn("De-registering service {} failed with status {}", target.getServiceType().asValue(), status);
+        }
+    }
+}

--- a/capabilities-services-client/src/main/java/ai/wanaku/capabilities/sdk/services/ServicesHttpClient.java
+++ b/capabilities-services-client/src/main/java/ai/wanaku/capabilities/sdk/services/ServicesHttpClient.java
@@ -3,6 +3,7 @@ package ai.wanaku.capabilities.sdk.services;
 import jakarta.ws.rs.core.MediaType;
 
 import ai.wanaku.api.exceptions.WanakuException;
+import ai.wanaku.api.types.DataStore;
 import ai.wanaku.api.types.ForwardReference;
 import ai.wanaku.api.types.Namespace;
 import ai.wanaku.api.types.ResourceReference;
@@ -10,6 +11,7 @@ import ai.wanaku.api.types.ToolReference;
 import ai.wanaku.api.types.WanakuResponse;
 import ai.wanaku.api.types.io.ResourcePayload;
 import ai.wanaku.api.types.io.ToolPayload;
+import ai.wanaku.capabilities.sdk.common.exceptions.WanakuWebException;
 import ai.wanaku.capabilities.sdk.common.serializer.Serializer;
 import ai.wanaku.capabilities.sdk.services.config.ServicesClientConfig;
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -87,7 +89,7 @@ public class ServicesHttpClient {
             if (response.statusCode() >= 200 && response.statusCode() < 300) {
                 return objectMapper.readValue(response.body(), typeReference);
             } else {
-                throw new WanakuException("HTTP error: " + response.statusCode() + " - " + response.body());
+                throw new WanakuWebException("HTTP error: " + response.statusCode() + " - " + response.body(), response.statusCode());
             }
         } catch (JsonProcessingException e) {
             throw new WanakuException("JSON processing error", e);
@@ -122,7 +124,7 @@ public class ServicesHttpClient {
             HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
 
             if (response.statusCode() < 200 || response.statusCode() >= 300) {
-                throw new WanakuException("HTTP error: " + response.statusCode() + " - " + response.body());
+                throw new WanakuWebException("HTTP error: " + response.statusCode() + " - " + response.body(), response.statusCode());
             }
         } catch (JsonProcessingException e) {
             throw new WanakuException("JSON processing error", e);
@@ -158,7 +160,7 @@ public class ServicesHttpClient {
             if (response.statusCode() >= 200 && response.statusCode() < 300) {
                 return objectMapper.readValue(response.body(), typeReference);
             } else {
-                throw new WanakuException("HTTP error: " + response.statusCode() + " - " + response.body());
+                throw new WanakuWebException("HTTP error: " + response.statusCode() + " - " + response.body(), response.statusCode());
             }
         } catch (JsonProcessingException e) {
             throw new WanakuException("JSON processing error", e);
@@ -370,5 +372,70 @@ public class ServicesHttpClient {
      */
     public WanakuResponse<List<Namespace>> listNamespaces() {
         return executeGet("/api/v1/namespaces/list", new TypeReference<WanakuResponse<List<Namespace>>>() {});
+    }
+
+    // ==================== DataStores API Methods ====================
+
+    /**
+     * Adds a new data store entry.
+     *
+     * @param dataStore The {@link DataStore} to add.
+     * @return The response containing the added data store.
+     * @throws WanakuException If an error occurs during the request.
+     */
+    public WanakuResponse<DataStore> addDataStore(DataStore dataStore) {
+        return executePost("/api/v1/data-store/add", dataStore, new TypeReference<WanakuResponse<DataStore>>() {});
+    }
+
+    /**
+     * Lists all data stores.
+     *
+     * @return The response containing the list of all data stores.
+     * @throws WanakuException If an error occurs during the request.
+     */
+    public WanakuResponse<List<DataStore>> listDataStores() {
+        return executeGet("/api/v1/data-store/list", new TypeReference<WanakuResponse<List<DataStore>>>() {});
+    }
+
+    /**
+     * Gets a data store by ID.
+     *
+     * @param id The ID of the data store to retrieve.
+     * @return The response containing the data store.
+     * @throws WanakuException If an error occurs during the request.
+     */
+    public WanakuResponse<DataStore> getDataStoreById(String id) {
+        return executeGet("/api/v1/data-store/get?id=" + id, new TypeReference<WanakuResponse<DataStore>>() {});
+    }
+
+    /**
+     * Gets data stores by name.
+     *
+     * @param name The name of the data stores to retrieve.
+     * @return The response containing the list of data stores.
+     * @throws WanakuException If an error occurs during the request.
+     */
+    public WanakuResponse<List<DataStore>> getDataStoresByName(String name) {
+        return executeGet("/api/v1/data-store/get?name=" + name, new TypeReference<WanakuResponse<List<DataStore>>>() {});
+    }
+
+    /**
+     * Removes a data store by ID.
+     *
+     * @param id The ID of the data store to remove.
+     * @throws WanakuException If an error occurs during the request.
+     */
+    public void removeDataStore(String id) {
+        executeDelete("/api/v1/data-store/remove?id=" + id);
+    }
+
+    /**
+     * Removes data stores by name.
+     *
+     * @param name The name of the data stores to remove.
+     * @throws WanakuException If an error occurs during the request.
+     */
+    public void removeDataStoresByName(String name) {
+        executeDelete("/api/v1/data-store/remove?name=" + name);
     }
 }


### PR DESCRIPTION
Added support for running callbacks after registration, ping and deregistration

Ref: wanaku-ai/wanaku#637

## Summary by Sourcery

Add DataStore API operations and callback support in discovery registration while refining HTTP error handling.

New Features:
- Add DataStore CRUD methods to ServicesHttpClient for managing data store entries.
- Implement callback mechanism in ZeroDepRegistrationManager to invoke DiscoveryCallback on registration, ping, and deregistration.
- Provide DiscoveryLogCallback as a default callback implementation for logging discovery events.

Enhancements:
- Introduce WanakuWebException for HTTP errors to include status codes and replace generic WanakuException in HTTP client methods.