### PR TITLE
Added OIDC discovery support

### DIFF
--- a/capabilities-security/src/main/java/ai/wanaku/capabilities/sdk/security/TokenEndpoint.java
+++ b/capabilities-security/src/main/java/ai/wanaku/capabilities/sdk/security/TokenEndpoint.java
@@ -30,4 +30,32 @@ public final class TokenEndpoint {
     public static String fromBaseUrl(String baseUrl) {
         return baseUrl + "/protocol/openid-connect/token";
     }
+
+    /**
+     * Constructs a token endpoint URL by appending the discovery OpenID Connect path to a base URL.
+     *
+     * @param baseUrl The base URL of the authentication server.
+     * @return The complete token endpoint URL.
+     */
+    public static String forDiscovery(String baseUrl) {
+        return baseUrl + "/q/oidc/";
+    }
+
+    /**
+     * Automatically resolve the best URI to use
+     * @param registrationUri
+     * @param tokenEndpointUri
+     * @return
+     */
+    public static String autoResolve(String registrationUri, String tokenEndpointUri) {
+        if (tokenEndpointUri != null) {
+            if (!tokenEndpointUri.isEmpty() && !tokenEndpointUri.endsWith("/realms/wanaku/")) {
+                return direct(tokenEndpointUri);
+            }
+
+            return fromBaseUrl(tokenEndpointUri);
+        }
+
+        return forDiscovery(registrationUri);
+    }
 }


### PR DESCRIPTION
## Summary by Sourcery

Add OIDC discovery-based resolution for token endpoints used by the service authenticator.

New Features:
- Support resolving the OAuth2/OIDC token endpoint via OpenID Provider discovery metadata instead of relying solely on configured URLs.

Enhancements:
- Introduce helper methods to construct token endpoint URLs for direct, base URL, and discovery-based configurations, including automatic selection of the appropriate strategy based on available URIs.