### PR TITLE
Add JaCoCo test coverage support

### DIFF
--- a/capabilities-parent/pom.xml
+++ b/capabilities-parent/pom.xml
@@ -35,6 +35,7 @@
         <oauth2-oidc-sdk.version>11.31.1</oauth2-oidc-sdk.version>
         <langchain4j.version>1.10.0</langchain4j.version>
         <mockito.version>5.18.0</mockito.version>
+        <jacoco-maven-plugin.version>0.8.13</jacoco-maven-plugin.version>
     </properties>
 
     <dependencyManagement>
@@ -107,5 +108,37 @@
         </dependency>
     </dependencies>
 
+    <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.jacoco</groupId>
+                    <artifactId>jacoco-maven-plugin</artifactId>
+                    <version>${jacoco-maven-plugin.version}</version>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+        <plugins>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>prepare-agent</id>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>report</id>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -80,6 +80,30 @@
 
     <profiles>
         <profile>
+            <id>coverage</id>
+            <properties>
+                <jacoco-maven-plugin.version>0.8.13</jacoco-maven-plugin.version>
+            </properties>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.jacoco</groupId>
+                        <artifactId>jacoco-maven-plugin</artifactId>
+                        <version>${jacoco-maven-plugin.version}</version>
+                        <executions>
+                            <execution>
+                                <id>report-aggregate</id>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>report-aggregate</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
             <id>dist</id>
             <build>
                 <plugins>


### PR DESCRIPTION
## Summary

- Add JaCoCo Maven plugin (v0.8.13) to capabilities-parent for per-module coverage reports
- Add `coverage` profile to root pom.xml for aggregated reporting

## Usage

```bash
mvn clean test -Pcoverage
# Reports: <module>/target/site/jacoco/index.html
```

## Test plan

- [x] Build passes with `mvn clean test`
- [x] JaCoCo reports generated in modules with tests