### PR TITLE
Fix early-access CI javadoc build failures

### DIFF
--- a/capabilities-api/src/main/java/ai/wanaku/capabilities/sdk/api/types/execution/package-info.java
+++ b/capabilities-api/src/main/java/ai/wanaku/capabilities/sdk/api/types/execution/package-info.java
@@ -11,7 +11,6 @@
  *   <li>{@link ai.wanaku.capabilities.sdk.api.types.execution.CodeExecutionEvent} - Events streamed during execution</li>
  *   <li>{@link ai.wanaku.capabilities.sdk.api.types.execution.CodeExecutionStatus} - Execution status enumeration</li>
  *   <li>{@link ai.wanaku.capabilities.sdk.api.types.execution.CodeExecutionEventType} - Event type enumeration</li>
- *   <li>{@link ai.wanaku.capabilities.sdk.api.types.execution.Language} - Supported programming languages</li>
  * </ul>
  *
  * @since 1.0.0

--- a/pom.xml
+++ b/pom.xml
@@ -18,6 +18,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <maven-gpg-plugin.version>3.2.8</maven-gpg-plugin.version>
+        <maven-javadoc-plugin.version>3.12.0</maven-javadoc-plugin.version>
         <central-publishing-maven-plugin.version>0.10.0</central-publishing-maven-plugin.version>
         <maven-release-plugin.version>3.1.1</maven-release-plugin.version>
         <maven-scm-plugin.version>2.1.0</maven-scm-plugin.version>
@@ -110,6 +111,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-javadoc-plugin</artifactId>
+                        <version>${maven-javadoc-plugin.version}</version>
                         <executions>
                             <execution>
                                 <id>attach-javadocs</id>


### PR DESCRIPTION
## Summary
- Add explicit version (3.12.0) to maven-javadoc-plugin in dist profile
- Remove reference to non-existent Language class in package-info.java

## Test plan
- [x] Verified javadoc build succeeds locally with `mvn -Pdist -pl capabilities-api javadoc:jar`

Fixes #61

## Summary by Sourcery

Fix Javadoc generation failures in the dist Maven profile.

Bug Fixes:
- Pin the maven-javadoc-plugin version in the dist profile to ensure compatible Javadoc generation.
- Remove an invalid Javadoc reference to a non-existent Language class from package-info.java.