### PR TITLE
Add HealthStatus enum for health check and heartbeat mechanism

### DIFF
--- a/capabilities-api/src/main/java/ai/wanaku/capabilities/sdk/api/types/discovery/ActivityRecord.java
+++ b/capabilities-api/src/main/java/ai/wanaku/capabilities/sdk/api/types/discovery/ActivityRecord.java
@@ -16,7 +16,7 @@ import ai.wanaku.capabilities.sdk.api.types.WanakuEntity;
 public class ActivityRecord implements WanakuEntity<String> {
     private String id;
     private Instant lastSeen;
-    private boolean active;
+    private HealthStatus healthStatus = HealthStatus.PENDING;
     private List<ServiceState> states = new ArrayList<>();
 
     /**
@@ -64,20 +64,32 @@ public class ActivityRecord implements WanakuEntity<String> {
 
     /**
      * Checks whether the service is currently active.
+     * <p>
+     * A service is considered active if its health status is {@link HealthStatus#HEALTHY}
+     * or {@link HealthStatus#PENDING}.
      *
      * @return {@code true} if the service is active, {@code false} otherwise
      */
     public boolean isActive() {
-        return active;
+        return healthStatus == HealthStatus.HEALTHY || healthStatus == HealthStatus.PENDING;
     }
 
     /**
-     * Sets the active status of the service.
+     * Gets the health status of this service.
      *
-     * @param active {@code true} to mark the service as active, {@code false} otherwise
+     * @return the current health status
      */
-    public void setActive(boolean active) {
-        this.active = active;
+    public HealthStatus getHealthStatus() {
+        return healthStatus;
+    }
+
+    /**
+     * Sets the health status of this service.
+     *
+     * @param healthStatus the health status to set
+     */
+    public void setHealthStatus(HealthStatus healthStatus) {
+        this.healthStatus = healthStatus;
     }
 
     /**
@@ -107,7 +119,7 @@ public class ActivityRecord implements WanakuEntity<String> {
             return false;
         }
         ActivityRecord that = (ActivityRecord) o;
-        return active == that.active
+        return healthStatus == that.healthStatus
                 && Objects.equals(id, that.id)
                 && Objects.equals(lastSeen, that.lastSeen)
                 && Objects.equals(states, that.states);
@@ -115,15 +127,15 @@ public class ActivityRecord implements WanakuEntity<String> {
 
     @Override
     public int hashCode() {
-        return Objects.hash(id, lastSeen, active, states);
+        return Objects.hash(id, lastSeen, healthStatus, states);
     }
 
     @Override
     public String toString() {
         return "ActivityRecord{" + "id='"
                 + id + '\'' + ", lastSeen="
-                + lastSeen + ", active="
-                + active + ", states="
+                + lastSeen + ", healthStatus="
+                + healthStatus + ", states="
                 + states + '}';
     }
 }

--- a/capabilities-api/src/main/java/ai/wanaku/capabilities/sdk/api/types/discovery/HealthStatus.java
+++ b/capabilities-api/src/main/java/ai/wanaku/capabilities/sdk/api/types/discovery/HealthStatus.java
@@ -1,0 +1,44 @@
+package ai.wanaku.capabilities.sdk.api.types.discovery;
+
+/**
+ * Represents the health status of a service in the Wanaku system.
+ */
+public enum HealthStatus {
+    PENDING("pending"),
+    HEALTHY("healthy"),
+    UNHEALTHY("unhealthy"),
+    DOWN("down");
+
+    private final String value;
+
+    HealthStatus(String value) {
+        this.value = value;
+    }
+
+    /**
+     * Returns the lowercase string representation of this health status.
+     *
+     * @return the status value as a lowercase string
+     */
+    public String asValue() {
+        return value;
+    }
+
+    /**
+     * Converts a string value to a HealthStatus enum constant.
+     *
+     * @param value the string value to convert
+     * @return the matching HealthStatus, or {@link #PENDING} if no match is found or value is null
+     */
+    public static HealthStatus fromValue(String value) {
+        if (value == null) {
+            return PENDING;
+        }
+        for (HealthStatus status : values()) {
+            if (status.value.equals(value)) {
+                return status;
+            }
+        }
+        return PENDING;
+    }
+}

--- a/capabilities-discovery/src/main/java/ai/wanaku/capabilities/sdk/discovery/ZeroDepRegistrationManager.java
+++ b/capabilities-discovery/src/main/java/ai/wanaku/capabilities/sdk/discovery/ZeroDepRegistrationManager.java
@@ -330,4 +330,8 @@ public class ZeroDepRegistrationManager implements RegistrationManager {
     public void addCallBack(DiscoveryCallback callback) {
         callbacks.add(callback);
     }
+
+    public ServiceTarget getTarget() {
+        return target;
+    }
 }

--- a/capabilities-exchange/src/main/proto/healthprobe.proto
+++ b/capabilities-exchange/src/main/proto/healthprobe.proto
@@ -1,0 +1,31 @@
+syntax = "proto3";
+
+option java_multiple_files = true;
+option java_package = "ai.wanaku.core.exchange";
+option java_outer_classname = "HealthProbeExchange";
+
+package health;
+
+// The health probe service definition.
+service HealthProbe {
+  // Gets the runtime status of the capability
+  rpc GetStatus (HealthProbeRequest) returns (HealthProbeReply) {}
+}
+
+// The health probe request message
+message HealthProbeRequest {
+  string id = 1;
+}
+
+// The runtime status of the capability
+enum RuntimeStatus {
+  STOPPED = 0;
+  STOPPING = 1;
+  STARTING = 2;
+  STARTED = 3;
+}
+
+// The health probe response message
+message HealthProbeReply {
+  RuntimeStatus status = 1;
+}

--- a/capabilities-runtimes/capabilities-runtimes-camel/capabilities-runtimes-camel-common/src/main/java/ai/wanaku/capabilities/sdk/runtime/camel/grpc/CamelHealthProbe.java
+++ b/capabilities-runtimes/capabilities-runtimes-camel/capabilities-runtimes-camel-common/src/main/java/ai/wanaku/capabilities/sdk/runtime/camel/grpc/CamelHealthProbe.java
@@ -1,0 +1,60 @@
+package ai.wanaku.capabilities.sdk.runtime.camel.grpc;
+
+import java.util.Objects;
+import org.apache.camel.CamelContext;
+import org.apache.camel.ServiceStatus;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import io.grpc.Status;
+import io.grpc.stub.StreamObserver;
+import ai.wanaku.capabilities.sdk.api.exceptions.WanakuException;
+import ai.wanaku.capabilities.sdk.api.types.providers.ServiceTarget;
+import ai.wanaku.core.exchange.HealthProbeGrpc;
+import ai.wanaku.core.exchange.HealthProbeReply;
+import ai.wanaku.core.exchange.HealthProbeRequest;
+import ai.wanaku.core.exchange.RuntimeStatus;
+
+public class CamelHealthProbe extends HealthProbeGrpc.HealthProbeImplBase {
+    private static final Logger LOG = LoggerFactory.getLogger(CamelHealthProbe.class);
+
+    private final CamelContext camelContext;
+    private final ServiceTarget target;
+
+    public CamelHealthProbe(CamelContext camelContext, ServiceTarget target) {
+        this.camelContext = camelContext;
+        this.target = Objects.requireNonNull(target);
+
+        if (target.getId().isEmpty()) {
+            throw new WanakuException("Invalid capability service ID");
+        }
+    }
+
+    public RuntimeStatus getStatus(ServiceStatus serviceStatus) {
+        switch (serviceStatus) {
+            case Initializing, Initialized, Starting -> {
+                return RuntimeStatus.STARTING;
+            }
+            case Started -> {
+                return RuntimeStatus.STARTED;
+            }
+            default -> {
+                return RuntimeStatus.STOPPED;
+            }
+        }
+    }
+
+    @Override
+    public void getStatus(HealthProbeRequest request, StreamObserver<HealthProbeReply> responseObserver) {
+        if (!target.getId().equals(request.getId())) {
+            LOG.error("Requested capability ID ({}) doesn't match exiting one {}", request.getId(), target.getId());
+            responseObserver.onError(Status.INVALID_ARGUMENT
+                    .withDescription("Invalid request id " + request.getId())
+                    .asRuntimeException());
+        } else {
+            RuntimeStatus status = getStatus(camelContext.getStatus());
+            responseObserver.onNext(
+                    HealthProbeReply.newBuilder().setStatus(status).build());
+            responseObserver.onCompleted();
+        }
+    }
+}

--- a/capabilities-runtimes/capabilities-runtimes-camel/capabilities-runtimes-camel-plugin/src/main/java/ai/wanaku/capabilities/sdk/runtime/camel/plugin/CamelIntegrationPlugin.java
+++ b/capabilities-runtimes/capabilities-runtimes-camel/capabilities-runtimes-camel-plugin/src/main/java/ai/wanaku/capabilities/sdk/runtime/camel/plugin/CamelIntegrationPlugin.java
@@ -14,7 +14,6 @@ import io.grpc.Grpc;
 import io.grpc.InsecureServerCredentials;
 import io.grpc.Server;
 import io.grpc.ServerBuilder;
-import ai.wanaku.capabilities.sdk.api.discovery.RegistrationManager;
 import ai.wanaku.capabilities.sdk.api.types.providers.ServiceTarget;
 import ai.wanaku.capabilities.sdk.api.types.providers.ServiceType;
 import ai.wanaku.capabilities.sdk.common.ServicesHelper;
@@ -32,6 +31,7 @@ import ai.wanaku.capabilities.sdk.runtime.camel.downloader.ResourceDownloaderCal
 import ai.wanaku.capabilities.sdk.runtime.camel.downloader.ResourceListBuilder;
 import ai.wanaku.capabilities.sdk.runtime.camel.downloader.ResourceRefs;
 import ai.wanaku.capabilities.sdk.runtime.camel.downloader.ResourceType;
+import ai.wanaku.capabilities.sdk.runtime.camel.grpc.CamelHealthProbe;
 import ai.wanaku.capabilities.sdk.runtime.camel.grpc.CamelResource;
 import ai.wanaku.capabilities.sdk.runtime.camel.grpc.CamelTool;
 import ai.wanaku.capabilities.sdk.runtime.camel.grpc.ProvisionBase;
@@ -57,7 +57,7 @@ public class CamelIntegrationPlugin implements ContextServicePlugin {
     private static final Logger LOG = LoggerFactory.getLogger(CamelIntegrationPlugin.class);
 
     private Server grpcServer;
-    private RegistrationManager registrationManager;
+    private ZeroDepRegistrationManager registrationManager;
     private PluginConfiguration config;
 
     @Override
@@ -117,6 +117,7 @@ public class CamelIntegrationPlugin implements ContextServicePlugin {
                     .addService(new CamelTool(camelContext, mcpSpec))
                     .addService(new CamelResource(camelContext, mcpSpec))
                     .addService(new ProvisionBase(config.getServiceName()))
+                    .addService(new CamelHealthProbe(camelContext, registrationManager.getTarget()))
                     .build();
 
             grpcServer.start();
@@ -156,7 +157,7 @@ public class CamelIntegrationPlugin implements ContextServicePlugin {
                 config.getServiceName(), address, config.getGrpcPort(), ServiceType.MULTI_CAPABILITY.asValue());
     }
 
-    private RegistrationManager newRegistrationManager(
+    private ZeroDepRegistrationManager newRegistrationManager(
             ServiceTarget serviceTarget,
             ResourceDownloaderCallback resourcesDownloaderCallback,
             ServiceConfig serviceConfig) {


### PR DESCRIPTION
## Summary

- Add `HealthStatus` enum with `PENDING`, `HEALTHY`, `UNHEALTHY`, `DOWN` values
- Update `ActivityRecord` to use `HealthStatus` with backward-compatible `isActive()`/`setActive()` methods
- Update `ServiceState` with `healthStatus` field and new factory methods (`newPending()`, `newDown()`)

## Context

Pre-requisite for wanaku-ai/wanaku#782 which adds health check and heartbeat mechanism for capabilities.

## Test plan
- [x] `mvn install` succeeds
- [x] Backward compatibility maintained via `isActive()`/`setActive()` bridge methods

## Summary by Sourcery

Introduce explicit health status modeling for services and wire it through discovery state tracking.

New Features:
- Add a HealthStatus enum to represent detailed service health states (pending, healthy, unhealthy, down).

Enhancements:
- Extend ServiceState to store a HealthStatus alongside the boolean healthy flag and expose new factory methods for pending and down states.
- Update ActivityRecord to derive and maintain its active flag from HealthStatus while preserving existing isActive/setActive behavior.
- Include HealthStatus in equality, hashing, and string representations of ActivityRecord and ServiceState for more accurate state comparison and logging.