### PR TITLE
chore: upgrade actions/checkout to v6 and actions/setup-java to v5

### DIFF
--- a/.github/workflows/early-access.yml
+++ b/.github/workflows/early-access.yml
@@ -14,12 +14,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Setup Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: 21
           distribution: 'zulu'

--- a/.github/workflows/pr-builds.yml
+++ b/.github/workflows/pr-builds.yml
@@ -41,12 +41,12 @@ jobs:
       fail-fast: true
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           persist-credentials: false
           fetch-depth: 0
       - name: Set up JDK 21
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: '21'
           distribution: 'temurin'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,14 +19,14 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       # Configure build steps as you'd normally do
 
       - name: Setup Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: 21
           distribution: 'zulu'


### PR DESCRIPTION
Upgrade GitHub Actions versions in remaining workflow files:

- `actions/checkout`: v4 → v6
- `actions/setup-java`: v4 → v5

Affected workflows: `early-access.yml`, `pr-builds.yml`, `release.yml`.
`main-build.yml` was already up to date.

## Summary by Sourcery

Update GitHub workflow configurations to use newer versions of checkout and Java setup actions.

CI:
- Bump actions/checkout from v4 to v6 across remaining CI workflows.
- Bump actions/setup-java from v4 to v5 in early-access, PR builds, and release workflows.