### PR TITLE
Disable capability-side ping by default

### DIFF
--- a/capabilities-discovery/src/main/java/ai/wanaku/capabilities/sdk/discovery/ZeroDepRegistrationManager.java
+++ b/capabilities-discovery/src/main/java/ai/wanaku/capabilities/sdk/discovery/ZeroDepRegistrationManager.java
@@ -176,7 +176,9 @@ public class ZeroDepRegistrationManager implements RegistrationManager {
     @Override
     public void register() {
         if (isRegistered()) {
-            ping();
+            if (config.isPingEnabled()) {
+                ping();
+            }
         } else {
             tryRegistering();
         }
@@ -218,6 +220,10 @@ public class ZeroDepRegistrationManager implements RegistrationManager {
      */
     @Override
     public void ping() {
+        if (!config.isPingEnabled()) {
+            return;
+        }
+
         if (target != null && target.getId() != null) {
             LOG.trace("Pinging router ...");
             try {

--- a/capabilities-discovery/src/main/java/ai/wanaku/capabilities/sdk/discovery/config/DefaultRegistrationConfig.java
+++ b/capabilities-discovery/src/main/java/ai/wanaku/capabilities/sdk/discovery/config/DefaultRegistrationConfig.java
@@ -11,6 +11,7 @@ public class DefaultRegistrationConfig implements RegistrationConfig {
     private final String dataDir;
     private final long initialDelay;
     private final long period;
+    private final boolean pingEnabled;
 
     /**
      * Private constructor to enforce the use of the {@link Builder}.
@@ -23,6 +24,7 @@ public class DefaultRegistrationConfig implements RegistrationConfig {
         this.dataDir = builder.dataDir;
         this.initialDelay = builder.initialDelay;
         this.period = builder.period;
+        this.pingEnabled = builder.pingEnabled;
     }
 
     /**
@@ -34,6 +36,7 @@ public class DefaultRegistrationConfig implements RegistrationConfig {
         private String dataDir;
         private long initialDelay;
         private long period;
+        private boolean pingEnabled;
 
         /**
          * Sets the maximum number of retries for registration attempts.
@@ -87,6 +90,17 @@ public class DefaultRegistrationConfig implements RegistrationConfig {
          */
         public Builder period(long period) {
             this.period = period;
+            return this;
+        }
+
+        /**
+         * Sets whether capability-side ping is enabled.
+         *
+         * @param pingEnabled {@code true} to enable ping, {@code false} to disable.
+         * @return The builder instance.
+         */
+        public Builder pingEnabled(boolean pingEnabled) {
+            this.pingEnabled = pingEnabled;
             return this;
         }
 
@@ -157,5 +171,10 @@ public class DefaultRegistrationConfig implements RegistrationConfig {
     @Override
     public long getPeriod() {
         return period;
+    }
+
+    @Override
+    public boolean isPingEnabled() {
+        return pingEnabled;
     }
 }

--- a/capabilities-discovery/src/main/java/ai/wanaku/capabilities/sdk/discovery/config/RegistrationConfig.java
+++ b/capabilities-discovery/src/main/java/ai/wanaku/capabilities/sdk/discovery/config/RegistrationConfig.java
@@ -35,4 +35,15 @@ public interface RegistrationConfig {
      * @return The period in seconds.
      */
     long getPeriod();
+
+    /**
+     * Returns whether capability-side ping is enabled.
+     * When disabled, the capability will not send periodic ping requests to the router
+     * after initial registration.
+     *
+     * @return {@code true} if ping is enabled, {@code false} otherwise. Defaults to {@code false}.
+     */
+    default boolean isPingEnabled() {
+        return false;
+    }
 }

--- a/capabilities-runtimes/capabilities-runtimes-camel/capabilities-runtimes-camel-plugin/src/main/java/ai/wanaku/capabilities/sdk/runtime/camel/plugin/CamelIntegrationPlugin.java
+++ b/capabilities-runtimes/capabilities-runtimes-camel/capabilities-runtimes-camel-plugin/src/main/java/ai/wanaku/capabilities/sdk/runtime/camel/plugin/CamelIntegrationPlugin.java
@@ -169,6 +169,7 @@ public class CamelIntegrationPlugin implements ContextServicePlugin {
                 .dataDir(ServicesHelper.getCanonicalServiceHome(config.getServiceName()))
                 .maxRetries(config.getRetries())
                 .waitSeconds(config.getRetryWaitSeconds())
+                .pingEnabled(config.isPingEnabled())
                 .build();
 
         ZeroDepRegistrationManager manager = new ZeroDepRegistrationManager(

--- a/capabilities-runtimes/capabilities-runtimes-camel/capabilities-runtimes-camel-plugin/src/main/java/ai/wanaku/capabilities/sdk/runtime/camel/plugin/PluginConfiguration.java
+++ b/capabilities-runtimes/capabilities-runtimes-camel/capabilities-runtimes-camel-plugin/src/main/java/ai/wanaku/capabilities/sdk/runtime/camel/plugin/PluginConfiguration.java
@@ -33,6 +33,7 @@ public class PluginConfiguration {
     private long initialDelay = 5;
     private long period = 5;
     private boolean noWait = false;
+    private boolean pingEnabled = false;
 
     /**
      * Load configuration from properties file and environment variables.
@@ -77,6 +78,7 @@ public class PluginConfiguration {
         config.initialDelay = Long.parseLong(getConfigValue(props, "initial.delay", "INITIAL_DELAY", "5"));
         config.period = Long.parseLong(getConfigValue(props, "period", "PERIOD", "5"));
         config.noWait = Boolean.parseBoolean(getConfigValue(props, "no.wait", "NO_WAIT", "false"));
+        config.pingEnabled = Boolean.parseBoolean(getConfigValue(props, "ping.enabled", "PING_ENABLED", "false"));
 
         return config;
     }
@@ -189,5 +191,9 @@ public class PluginConfiguration {
 
     public boolean isNoWait() {
         return noWait;
+    }
+
+    public boolean isPingEnabled() {
+        return pingEnabled;
     }
 }

--- a/capabilities-runtimes/capabilities-runtimes-camel/capabilities-runtimes-camel-plugin/src/main/resources/camel-integration-capability.properties
+++ b/capabilities-runtimes/capabilities-runtimes-camel/capabilities-runtimes-camel-plugin/src/main/resources/camel-integration-capability.properties
@@ -62,3 +62,7 @@ period=5
 
 # Env: NO_WAIT
 no.wait=false
+
+# Capability-side ping (disabled by default)
+# Env: PING_ENABLED
+ping.enabled=false


### PR DESCRIPTION
## Summary
- Add `isPingEnabled()` to `RegistrationConfig` interface with default `false`
- Add `pingEnabled` field to `DefaultRegistrationConfig` builder
- Guard ping call in `ZeroDepRegistrationManager.register()` behind the flag
- Add `ping.enabled` / `PING_ENABLED` configuration to `PluginConfiguration` and properties file

## Test plan
- [ ] Verify build passes (`mvn verify`)
- [ ] Confirm capability no longer pings by default after registration
- [ ] Confirm ping can be enabled by setting `ping.enabled=true` or `PING_ENABLED=true`

Ref: wanaku-ai/wanaku#804

## Summary by Sourcery

Disable capability-side ping by default and make it configurable via registration and plugin settings.

New Features:
- Introduce a configurable flag on registration config to enable or disable capability-side ping.
- Add plugin-level configuration options and properties for controlling capability-side ping via file or environment variables.

Enhancements:
- Ensure the registration manager only triggers ping when capability-side ping is explicitly enabled.