### PR TITLE
feat: add service catalog support to SDK

### DIFF
--- a/capabilities-runtimes/capabilities-runtimes-camel/capabilities-runtimes-camel-common/src/main/java/ai/wanaku/capabilities/sdk/runtime/camel/downloader/DownloaderConfiguration.java
+++ b/capabilities-runtimes/capabilities-runtimes-camel/capabilities-runtimes-camel-common/src/main/java/ai/wanaku/capabilities/sdk/runtime/camel/downloader/DownloaderConfiguration.java
@@ -5,12 +5,12 @@ package ai.wanaku.capabilities.sdk.runtime.camel.downloader;
  * Built using the builder pattern, this class holds the retry policy and any other
  * download-related configuration.
  */
-public class ResourceDownloaderConfiguration {
+public class DownloaderConfiguration {
     private static final RetryPolicy NO_RETRY = new NoRetryPolicy();
 
     private final RetryPolicy retryPolicy;
 
-    private ResourceDownloaderConfiguration(Builder builder) {
+    private DownloaderConfiguration(Builder builder) {
         this.retryPolicy = builder.retryPolicy;
     }
 
@@ -21,7 +21,7 @@ public class ResourceDownloaderConfiguration {
     /**
      * Returns a default configuration with no retry.
      */
-    public static ResourceDownloaderConfiguration defaultConfig() {
+    public static DownloaderConfiguration defaultConfig() {
         return newBuilder().build();
     }
 
@@ -39,8 +39,8 @@ public class ResourceDownloaderConfiguration {
             return this;
         }
 
-        public ResourceDownloaderConfiguration build() {
-            return new ResourceDownloaderConfiguration(this);
+        public DownloaderConfiguration build() {
+            return new DownloaderConfiguration(this);
         }
     }
 

--- a/capabilities-runtimes/capabilities-runtimes-camel/capabilities-runtimes-camel-common/src/main/java/ai/wanaku/capabilities/sdk/runtime/camel/downloader/DownloaderFactory.java
+++ b/capabilities-runtimes/capabilities-runtimes-camel/capabilities-runtimes-camel-common/src/main/java/ai/wanaku/capabilities/sdk/runtime/camel/downloader/DownloaderFactory.java
@@ -20,6 +20,14 @@ public class DownloaderFactory {
         this.dataDir = dataDir;
     }
 
+    public ServicesHttpClient getServicesHttpClient() {
+        return servicesHttpClient;
+    }
+
+    public Path getDataDir() {
+        return dataDir;
+    }
+
     public Downloader getDownloader(URI uri) {
         if (uri == null || uri.getScheme() == null) {
             throw new IllegalArgumentException("URI and scheme cannot be null");

--- a/capabilities-runtimes/capabilities-runtimes-camel/capabilities-runtimes-camel-common/src/main/java/ai/wanaku/capabilities/sdk/runtime/camel/downloader/ResourceDownloaderCallback.java
+++ b/capabilities-runtimes/capabilities-runtimes-camel/capabilities-runtimes-camel-common/src/main/java/ai/wanaku/capabilities/sdk/runtime/camel/downloader/ResourceDownloaderCallback.java
@@ -20,17 +20,17 @@ public class ResourceDownloaderCallback implements DiscoveryCallback {
     private final CountDownLatch countDownLatch = new CountDownLatch(1);
 
     private final DownloaderFactory downloaderFactory;
-    private final ResourceDownloaderConfiguration configuration;
+    private final DownloaderConfiguration configuration;
     private Map<ResourceType, Path> downloadedResources = new HashMap<>();
 
     public ResourceDownloaderCallback(DownloaderFactory downloaderFactory, List<ResourceRefs<URI>> resources) {
-        this(downloaderFactory, resources, ResourceDownloaderConfiguration.defaultConfig());
+        this(downloaderFactory, resources, DownloaderConfiguration.defaultConfig());
     }
 
     public ResourceDownloaderCallback(
             DownloaderFactory downloaderFactory,
             List<ResourceRefs<URI>> resources,
-            ResourceDownloaderConfiguration configuration) {
+            DownloaderConfiguration configuration) {
         this.resources = resources;
         this.downloaderFactory = downloaderFactory;
         this.configuration = configuration;

--- a/capabilities-runtimes/capabilities-runtimes-camel/capabilities-runtimes-camel-common/src/main/java/ai/wanaku/capabilities/sdk/runtime/camel/downloader/ServiceCatalogDownloaderCallback.java
+++ b/capabilities-runtimes/capabilities-runtimes-camel/capabilities-runtimes-camel-common/src/main/java/ai/wanaku/capabilities/sdk/runtime/camel/downloader/ServiceCatalogDownloaderCallback.java
@@ -1,0 +1,127 @@
+package ai.wanaku.capabilities.sdk.runtime.camel.downloader;
+
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import ai.wanaku.capabilities.sdk.api.discovery.DiscoveryCallback;
+import ai.wanaku.capabilities.sdk.api.discovery.RegistrationManager;
+import ai.wanaku.capabilities.sdk.api.types.DataStore;
+import ai.wanaku.capabilities.sdk.api.types.WanakuResponse;
+import ai.wanaku.capabilities.sdk.api.types.providers.ServiceTarget;
+
+public class ServiceCatalogDownloaderCallback implements DiscoveryCallback {
+    private static final Logger LOG = LoggerFactory.getLogger(ServiceCatalogDownloaderCallback.class);
+
+    private final DownloaderFactory downloaderFactory;
+    private final String catalogName;
+    private final String systemName;
+    private final DownloaderConfiguration configuration;
+    private final CountDownLatch countDownLatch = new CountDownLatch(1);
+    private Map<ResourceType, Path> downloadedResources = new HashMap<>();
+    private boolean success;
+
+    public ServiceCatalogDownloaderCallback(
+            DownloaderFactory downloaderFactory, String catalogName, String systemName) {
+        this(downloaderFactory, catalogName, systemName, DownloaderConfiguration.defaultConfig());
+    }
+
+    public ServiceCatalogDownloaderCallback(
+            DownloaderFactory downloaderFactory,
+            String catalogName,
+            String systemName,
+            DownloaderConfiguration configuration) {
+        this.downloaderFactory = downloaderFactory;
+        this.catalogName = catalogName;
+        this.systemName = systemName;
+        this.configuration = configuration;
+    }
+
+    @Override
+    public void onPing(RegistrationManager manager, ServiceTarget target, int status) {}
+
+    @Override
+    public void onRegistration(RegistrationManager manager, ServiceTarget target) {
+        try {
+            downloadServiceCatalogWithRetry();
+        } finally {
+            countDownLatch.countDown();
+        }
+    }
+
+    @Override
+    public void onDeregistration(RegistrationManager manager, ServiceTarget target, int status) {}
+
+    private void downloadServiceCatalogWithRetry() {
+        RetryPolicy retryPolicy = configuration.getRetryPolicy();
+        int maxAttempts = 1 + retryPolicy.maxRetries();
+
+        for (int attempt = 1; attempt <= maxAttempts; attempt++) {
+            try {
+                LOG.info(
+                        "Downloading service catalog '{}' for system '{}' (attempt {}/{})",
+                        catalogName,
+                        systemName,
+                        attempt,
+                        maxAttempts);
+
+                WanakuResponse<DataStore> response =
+                        downloaderFactory.getServicesHttpClient().getServiceCatalog(catalogName);
+                if (response == null || response.data() == null) {
+                    LOG.error("Service catalog '{}' not found", catalogName);
+                    return;
+                }
+
+                DataStore catalog = response.data();
+                if (catalog.getData() == null || catalog.getData().isBlank()) {
+                    LOG.error("Service catalog '{}' contains no data", catalogName);
+                    return;
+                }
+
+                downloadedResources =
+                        ServiceCatalogExtractor.extract(catalog.getData(), systemName, downloaderFactory.getDataDir());
+                LOG.info("Extracted {} resource(s) from service catalog", downloadedResources.size());
+                success = true;
+                return;
+            } catch (Exception e) {
+                if (attempt >= maxAttempts || !retryPolicy.isRetryable(e)) {
+                    LOG.error("Failed to download service catalog '{}': {}", catalogName, e.getMessage(), e);
+                    return;
+                }
+
+                long delay = retryPolicy.getDelayMillis(attempt);
+                LOG.warn(
+                        "Download attempt {}/{} failed for service catalog '{}': {}. Retrying in {} ms",
+                        attempt,
+                        maxAttempts,
+                        catalogName,
+                        e.getMessage(),
+                        delay);
+
+                try {
+                    Thread.sleep(delay);
+                } catch (InterruptedException ie) {
+                    Thread.currentThread().interrupt();
+                    return;
+                }
+            }
+        }
+    }
+
+    public boolean waitForDownloads() {
+        LOG.info("Waiting for service catalog download");
+        try {
+            countDownLatch.await();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+
+        return success;
+    }
+
+    public Map<ResourceType, Path> getDownloadedResources() {
+        return downloadedResources;
+    }
+}

--- a/capabilities-runtimes/capabilities-runtimes-camel/capabilities-runtimes-camel-common/src/main/java/ai/wanaku/capabilities/sdk/runtime/camel/downloader/ServiceCatalogExtractor.java
+++ b/capabilities-runtimes/capabilities-runtimes-camel/capabilities-runtimes-camel-common/src/main/java/ai/wanaku/capabilities/sdk/runtime/camel/downloader/ServiceCatalogExtractor.java
@@ -1,0 +1,138 @@
+package ai.wanaku.capabilities.sdk.runtime.camel.downloader;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Base64;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipInputStream;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import ai.wanaku.capabilities.sdk.api.exceptions.WanakuException;
+
+/**
+ * Extracts files from a service catalog ZIP archive for a given system.
+ * <p>
+ * The ZIP must contain an {@code index.properties} file with entries like:
+ * <pre>
+ * catalog.name=my-catalog
+ * catalog.services=system1,system2
+ * catalog.routes.system1=system1/routes.camel.yaml
+ * catalog.rules.system1=system1/rules.wanaku-rules.yaml
+ * catalog.dependencies.system1=system1/dependencies.txt
+ * </pre>
+ */
+public final class ServiceCatalogExtractor {
+    private static final Logger LOG = LoggerFactory.getLogger(ServiceCatalogExtractor.class);
+
+    private static final String INDEX_FILE = "index.properties";
+    private static final String PROP_ROUTES_PREFIX = "catalog.routes.";
+    private static final String PROP_RULES_PREFIX = "catalog.rules.";
+    private static final String PROP_DEPENDENCIES_PREFIX = "catalog.dependencies.";
+
+    private ServiceCatalogExtractor() {}
+
+    /**
+     * Extracts routes, rules, and optionally dependencies files for a given system
+     * from a Base64-encoded service catalog ZIP archive.
+     *
+     * @param base64Data the Base64-encoded ZIP data
+     * @param system     the system name to extract files for
+     * @param dataDir    the directory where extracted files will be written
+     * @return a map of resource types to their extracted file paths
+     * @throws WanakuException if the ZIP is invalid or required files are missing
+     */
+    public static Map<ResourceType, Path> extract(String base64Data, String system, Path dataDir)
+            throws WanakuException {
+        byte[] zipBytes;
+        try {
+            zipBytes = Base64.getDecoder().decode(base64Data);
+        } catch (IllegalArgumentException e) {
+            throw new WanakuException("Invalid Base64 data: " + e.getMessage(), e);
+        }
+
+        Properties props = readIndex(zipBytes);
+        String routesEntry = requireProperty(props, PROP_ROUTES_PREFIX + system, system);
+        String rulesEntry = requireProperty(props, PROP_RULES_PREFIX + system, system);
+        String depsEntry = props.getProperty(PROP_DEPENDENCIES_PREFIX + system);
+
+        Map<String, ResourceType> entriesToExtract = new HashMap<>();
+        entriesToExtract.put(routesEntry, ResourceType.ROUTES_REF);
+        entriesToExtract.put(rulesEntry, ResourceType.RULES_REF);
+        if (depsEntry != null && !depsEntry.isBlank()) {
+            entriesToExtract.put(depsEntry.trim(), ResourceType.DEPENDENCY_REF);
+        }
+
+        Map<ResourceType, Path> result = extractEntries(zipBytes, entriesToExtract, dataDir);
+
+        if (!result.containsKey(ResourceType.ROUTES_REF)) {
+            throw new WanakuException(
+                    "Routes file '" + routesEntry + "' for system '" + system + "' not found in catalog ZIP");
+        }
+        if (!result.containsKey(ResourceType.RULES_REF)) {
+            throw new WanakuException(
+                    "Rules file '" + rulesEntry + "' for system '" + system + "' not found in catalog ZIP");
+        }
+
+        return result;
+    }
+
+    private static Properties readIndex(byte[] zipBytes) throws WanakuException {
+        try (ZipInputStream zis = new ZipInputStream(new ByteArrayInputStream(zipBytes))) {
+            ZipEntry entry;
+            while ((entry = zis.getNextEntry()) != null) {
+                if (INDEX_FILE.equals(entry.getName())) {
+                    Properties props = new Properties();
+                    props.load(zis);
+                    return props;
+                }
+                zis.closeEntry();
+            }
+        } catch (IOException e) {
+            throw new WanakuException("Failed to read catalog ZIP: " + e.getMessage(), e);
+        }
+        throw new WanakuException("Catalog ZIP does not contain " + INDEX_FILE);
+    }
+
+    private static Map<ResourceType, Path> extractEntries(
+            byte[] zipBytes, Map<String, ResourceType> entriesToExtract, Path dataDir) throws WanakuException {
+        Map<ResourceType, Path> result = new HashMap<>();
+
+        try (ZipInputStream zis = new ZipInputStream(new ByteArrayInputStream(zipBytes))) {
+            ZipEntry entry;
+            while ((entry = zis.getNextEntry()) != null) {
+                ResourceType type = entriesToExtract.get(entry.getName());
+                if (type != null) {
+                    Path targetPath = dataDir.resolve(entry.getName());
+                    Files.createDirectories(targetPath.getParent());
+
+                    try (OutputStream out = Files.newOutputStream(targetPath)) {
+                        zis.transferTo(out);
+                    }
+
+                    result.put(type, targetPath);
+                    LOG.info("Extracted catalog file '{}' to {}", entry.getName(), targetPath);
+                }
+                zis.closeEntry();
+            }
+        } catch (IOException e) {
+            throw new WanakuException("Failed to extract catalog files: " + e.getMessage(), e);
+        }
+
+        return result;
+    }
+
+    private static String requireProperty(Properties props, String key, String system) throws WanakuException {
+        String value = props.getProperty(key);
+        if (value == null || value.isBlank()) {
+            throw new WanakuException(
+                    "System '" + system + "' not found in catalog index (missing property: " + key + ")");
+        }
+        return value.trim();
+    }
+}

--- a/capabilities-runtimes/capabilities-runtimes-camel/capabilities-runtimes-camel-common/src/test/java/ai/wanaku/capabilities/sdk/runtime/camel/downloader/ServiceCatalogExtractorTest.java
+++ b/capabilities-runtimes/capabilities-runtimes-camel/capabilities-runtimes-camel-common/src/test/java/ai/wanaku/capabilities/sdk/runtime/camel/downloader/ServiceCatalogExtractorTest.java
@@ -1,0 +1,158 @@
+package ai.wanaku.capabilities.sdk.runtime.camel.downloader;
+
+import java.io.ByteArrayOutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Base64;
+import java.util.Map;
+import java.util.Properties;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+import ai.wanaku.capabilities.sdk.api.exceptions.WanakuException;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ServiceCatalogExtractorTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void testExtractRoutesAndRules() throws Exception {
+        String base64Zip = createTestZip("test-catalog", "sys1");
+        Map<ResourceType, Path> result = ServiceCatalogExtractor.extract(base64Zip, "sys1", tempDir);
+
+        assertNotNull(result);
+        assertEquals(2, result.size());
+        assertTrue(result.containsKey(ResourceType.ROUTES_REF));
+        assertTrue(result.containsKey(ResourceType.RULES_REF));
+        assertTrue(Files.exists(result.get(ResourceType.ROUTES_REF)));
+        assertTrue(Files.exists(result.get(ResourceType.RULES_REF)));
+
+        String routesContent = Files.readString(result.get(ResourceType.ROUTES_REF));
+        assertEquals("# Routes for sys1", routesContent);
+    }
+
+    @Test
+    void testExtractWithDependencies() throws Exception {
+        String base64Zip = createTestZipWithDeps("test-catalog", "sys1");
+        Map<ResourceType, Path> result = ServiceCatalogExtractor.extract(base64Zip, "sys1", tempDir);
+
+        assertEquals(3, result.size());
+        assertTrue(result.containsKey(ResourceType.DEPENDENCY_REF));
+        assertTrue(Files.exists(result.get(ResourceType.DEPENDENCY_REF)));
+    }
+
+    @Test
+    void testExtractUnknownSystem() {
+        String base64Zip = createTestZip("test-catalog", "sys1");
+        assertThrows(WanakuException.class, () -> ServiceCatalogExtractor.extract(base64Zip, "nonexistent", tempDir));
+    }
+
+    @Test
+    void testExtractInvalidBase64() {
+        assertThrows(
+                WanakuException.class, () -> ServiceCatalogExtractor.extract("not-valid-base64!@#", "sys1", tempDir));
+    }
+
+    @Test
+    void testExtractMissingRoutesProperty() {
+        String base64Zip = createZipWithMissingProperty("catalog.routes.sys1");
+        WanakuException ex =
+                assertThrows(WanakuException.class, () -> ServiceCatalogExtractor.extract(base64Zip, "sys1", tempDir));
+        assertTrue(ex.getMessage().contains("catalog.routes.sys1"));
+    }
+
+    @Test
+    void testExtractMissingRulesProperty() {
+        String base64Zip = createZipWithMissingProperty("catalog.rules.sys1");
+        WanakuException ex =
+                assertThrows(WanakuException.class, () -> ServiceCatalogExtractor.extract(base64Zip, "sys1", tempDir));
+        assertTrue(ex.getMessage().contains("catalog.rules.sys1"));
+    }
+
+    private String createTestZip(String name, String... systems) {
+        return createTestZipInternal(name, false, systems);
+    }
+
+    private String createTestZipWithDeps(String name, String... systems) {
+        return createTestZipInternal(name, true, systems);
+    }
+
+    private String createTestZipInternal(String name, boolean includeDeps, String... systems) {
+        try {
+            ByteArrayOutputStream baos = new ByteArrayOutputStream();
+            try (ZipOutputStream zos = new ZipOutputStream(baos)) {
+                Properties props = new Properties();
+                props.setProperty("catalog.name", name);
+                props.setProperty("catalog.description", "Test catalog");
+                props.setProperty("catalog.services", String.join(",", systems));
+
+                for (String sys : systems) {
+                    String routesPath = sys + "/" + sys + ".camel.yaml";
+                    String rulesPath = sys + "/" + sys + ".wanaku-rules.yaml";
+                    props.setProperty("catalog.routes." + sys, routesPath);
+                    props.setProperty("catalog.rules." + sys, rulesPath);
+
+                    zos.putNextEntry(new ZipEntry(routesPath));
+                    zos.write(("# Routes for " + sys).getBytes());
+                    zos.closeEntry();
+
+                    zos.putNextEntry(new ZipEntry(rulesPath));
+                    zos.write(("# Rules for " + sys).getBytes());
+                    zos.closeEntry();
+
+                    if (includeDeps) {
+                        String depsPath = sys + "/" + sys + ".dependencies.txt";
+                        props.setProperty("catalog.dependencies." + sys, depsPath);
+
+                        zos.putNextEntry(new ZipEntry(depsPath));
+                        zos.write(("camel:camel-http:" + sys).getBytes());
+                        zos.closeEntry();
+                    }
+                }
+
+                zos.putNextEntry(new ZipEntry("index.properties"));
+                ByteArrayOutputStream propsOut = new ByteArrayOutputStream();
+                props.store(propsOut, null);
+                zos.write(propsOut.toByteArray());
+                zos.closeEntry();
+            }
+            return Base64.getEncoder().encodeToString(baos.toByteArray());
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private String createZipWithMissingProperty(String propertyToOmit) {
+        try {
+            ByteArrayOutputStream baos = new ByteArrayOutputStream();
+            try (ZipOutputStream zos = new ZipOutputStream(baos)) {
+                Properties props = new Properties();
+                props.setProperty("catalog.name", "test-catalog");
+                props.setProperty("catalog.services", "sys1");
+
+                if (!propertyToOmit.equals("catalog.routes.sys1")) {
+                    props.setProperty("catalog.routes.sys1", "sys1/sys1.camel.yaml");
+                }
+                if (!propertyToOmit.equals("catalog.rules.sys1")) {
+                    props.setProperty("catalog.rules.sys1", "sys1/sys1.wanaku-rules.yaml");
+                }
+
+                zos.putNextEntry(new ZipEntry("index.properties"));
+                ByteArrayOutputStream propsOut = new ByteArrayOutputStream();
+                props.store(propsOut, null);
+                zos.write(propsOut.toByteArray());
+                zos.closeEntry();
+            }
+            return Base64.getEncoder().encodeToString(baos.toByteArray());
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/capabilities-runtimes/capabilities-runtimes-camel/capabilities-runtimes-camel-plugin/src/main/java/ai/wanaku/capabilities/sdk/runtime/camel/plugin/CamelIntegrationPlugin.java
+++ b/capabilities-runtimes/capabilities-runtimes-camel/capabilities-runtimes-camel-plugin/src/main/java/ai/wanaku/capabilities/sdk/runtime/camel/plugin/CamelIntegrationPlugin.java
@@ -26,10 +26,10 @@ import ai.wanaku.capabilities.sdk.discovery.ZeroDepRegistrationManager;
 import ai.wanaku.capabilities.sdk.discovery.config.DefaultRegistrationConfig;
 import ai.wanaku.capabilities.sdk.discovery.deserializer.JacksonDeserializer;
 import ai.wanaku.capabilities.sdk.discovery.util.DiscoveryHelper;
+import ai.wanaku.capabilities.sdk.runtime.camel.downloader.DownloaderConfiguration;
 import ai.wanaku.capabilities.sdk.runtime.camel.downloader.DownloaderFactory;
 import ai.wanaku.capabilities.sdk.runtime.camel.downloader.ExponentialBackoffRetryPolicy;
 import ai.wanaku.capabilities.sdk.runtime.camel.downloader.ResourceDownloaderCallback;
-import ai.wanaku.capabilities.sdk.runtime.camel.downloader.ResourceDownloaderConfiguration;
 import ai.wanaku.capabilities.sdk.runtime.camel.downloader.ResourceListBuilder;
 import ai.wanaku.capabilities.sdk.runtime.camel.downloader.ResourceRefs;
 import ai.wanaku.capabilities.sdk.runtime.camel.downloader.ResourceType;
@@ -97,7 +97,7 @@ public class CamelIntegrationPlugin implements ContextServicePlugin {
                     .addDependenciesRef(config.getDependenciesRef())
                     .buildForPlugin();
 
-            ResourceDownloaderConfiguration downloaderConfig = ResourceDownloaderConfiguration.newBuilder()
+            DownloaderConfiguration downloaderConfig = DownloaderConfiguration.newBuilder()
                     .retryPolicy(ExponentialBackoffRetryPolicy.newBuilder()
                             .maxRetries(config.getRetries())
                             .build())

--- a/capabilities-services-client/src/main/java/ai/wanaku/capabilities/sdk/services/ServicesHttpClient.java
+++ b/capabilities-services-client/src/main/java/ai/wanaku/capabilities/sdk/services/ServicesHttpClient.java
@@ -483,6 +483,19 @@ public class ServicesHttpClient {
         executeDelete("/api/v1/data-store?name=" + encode(name));
     }
 
+    // ==================== Service Catalog API Methods ====================
+
+    /**
+     * Downloads a service catalog by name, returning the raw DataStore with Base64-encoded ZIP data.
+     *
+     * @param name The name of the service catalog to download.
+     * @return The response containing the DataStore with the Base64-encoded ZIP.
+     * @throws WanakuException If an error occurs during the request.
+     */
+    public WanakuResponse<DataStore> getServiceCatalog(String name) {
+        return executeGet("/api/v1/service-catalog/download?name=" + encode(name), new TypeReference<>() {});
+    }
+
     // ==================== Code Execution Engine API Methods ====================
 
     /**


### PR DESCRIPTION
## Summary
- Add `getServiceCatalog(String name)` method to `ServicesHttpClient` for fetching catalogs from the router's `/api/v1/service-catalog/download` endpoint
- Add `ServiceCatalogExtractor` utility that extracts routes, rules, and dependencies from a Base64-encoded catalog ZIP for a given system

## Test plan
- [x] Unit tests for `ServiceCatalogExtractor` (with/without dependencies, unknown system, invalid Base64)
- [x] `mvn verify` passes
- [ ] Integration test with deployed catalog on router

## Summary by Sourcery

Add support for downloading and extracting service catalogs in the SDK and Camel runtime.

New Features:
- Expose a ServicesHttpClient API to download service catalogs from the router.
- Introduce ServiceCatalogExtractor to decode catalog archives and extract system-specific resources.
- Add a ServiceCatalogDownloaderCallback that downloads and unpacks service catalogs on service registration.

Enhancements:
- Rename and generalize the downloader configuration type and expose DownloaderFactory accessors for reuse by service-catalog-related components.

Tests:
- Add unit tests covering ServiceCatalogExtractor behavior for valid catalogs, catalogs with dependencies, unknown systems, and invalid Base64 data.