### PR TITLE
chore: add --no-transfer-progress to Maven CI builds

### DIFF
--- a/.github/workflows/early-access.yml
+++ b/.github/workflows/early-access.yml
@@ -37,4 +37,4 @@ jobs:
           MAVEN_GPG_PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
         run: |
           export GPG_TTY=$(tty)
-          mvn -Pdist -B --file pom.xml deploy
+          mvn -Pdist -B --no-transfer-progress --file pom.xml deploy

--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -31,4 +31,4 @@ jobs:
         distribution: 'temurin'
         cache: maven
     - name: Build with Maven
-      run: mvn -B install --file pom.xml
+      run: mvn -B --no-transfer-progress install --file pom.xml

--- a/.github/workflows/pr-builds.yml
+++ b/.github/workflows/pr-builds.yml
@@ -52,4 +52,4 @@ jobs:
           distribution: 'temurin'
           cache: maven
       - name: Build with Maven
-        run: mvn -B install --file pom.xml
+        run: mvn -B --no-transfer-progress install --file pom.xml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,7 +46,7 @@ jobs:
           export GPG_TTY=$(tty)
           git config user.name "${{ github.actor }}"
           git config user.email "${{ github.actor }}@users.noreply.github.com"
-          mvn -Pdist -B --file pom.xml -Dtag=wanaku-capabilities-java-sdk-${{ github.event.inputs.currentDevelopmentVersion }} -DreleaseVersion=${{ github.event.inputs.currentDevelopmentVersion }} -DdevelopmentVersion=${{ github.event.inputs.nextDevelopmentVersion }}-SNAPSHOT release:prepare release:perform
+          mvn -Pdist -B --no-transfer-progress --file pom.xml -Dtag=wanaku-capabilities-java-sdk-${{ github.event.inputs.currentDevelopmentVersion }} -DreleaseVersion=${{ github.event.inputs.currentDevelopmentVersion }} -DdevelopmentVersion=${{ github.event.inputs.nextDevelopmentVersion }}-SNAPSHOT release:prepare release:perform
 
       # Create a release
 


### PR DESCRIPTION
## Summary
- Adds `--no-transfer-progress` flag to all Maven commands in GitHub Actions workflows
- Reduces CI log noise by suppressing artifact download/upload progress output
- Applied to: `main-build.yml`, `pr-builds.yml`, `early-access.yml`, `release.yml`

## Summary by Sourcery

CI:
- Update all Maven invocations in GitHub Actions workflows to include the --no-transfer-progress flag for quieter logs.