### PR TITLE
chore: clean up Maven POM files

### DIFF
--- a/capabilities-exchange/pom.xml
+++ b/capabilities-exchange/pom.xml
@@ -47,7 +47,7 @@
             <extension>
                 <groupId>kr.motd.maven</groupId>
                 <artifactId>os-maven-plugin</artifactId>
-                <version>1.7.1</version>
+                <version>${os-maven-plugin.version}</version>
             </extension>
         </extensions>
 
@@ -57,9 +57,9 @@
                 <artifactId>protobuf-maven-plugin</artifactId>
                 <version>${protobuf-maven-plugin.version}</version>
                 <configuration>
-                    <protocArtifact>com.google.protobuf:protoc:${protoc-version}:exe:${os.detected.classifier}</protocArtifact>
+                    <protocArtifact>com.google.protobuf:protoc:${protoc.version}:exe:${os.detected.classifier}</protocArtifact>
                     <pluginId>grpc-java</pluginId>
-                    <pluginArtifact>io.grpc:protoc-gen-grpc-java:${protoc-gen-grpc-java}:exe:${os.detected.classifier}
+                    <pluginArtifact>io.grpc:protoc-gen-grpc-java:${protoc-gen-grpc-java.version}:exe:${os.detected.classifier}
                     </pluginArtifact>
                 </configuration>
                 <executions>
@@ -74,6 +74,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
+                <version>${maven-source-plugin.version}</version>
                 <executions>
                     <execution>
                         <id>attach-sources</id>

--- a/capabilities-parent/pom.xml
+++ b/capabilities-parent/pom.xml
@@ -15,28 +15,28 @@
 
     <properties>
         <maven-dependency-plugin.version>3.9.0</maven-dependency-plugin.version>
+        <maven-failsafe-plugin.version>3.5.5</maven-failsafe-plugin.version>
+        <os-maven-plugin.version>1.7.1</os-maven-plugin.version>
         <protobuf-maven-plugin.version>0.6.1</protobuf-maven-plugin.version>
+        <spotless-maven-plugin.version>3.2.1</spotless-maven-plugin.version>
 
         <camel.version>4.18.0</camel.version>
         <jgit.version>7.5.0.202512021534-r</jgit.version>
         <jackson-dataformat-yaml.version>2.21.0</jackson-dataformat-yaml.version>
         <jackson-databind.version>2.21.0</jackson-databind.version>
         <jackson-annotations.version>2.21</jackson-annotations.version>
-        <jackson-dataformat-yaml.version>2.21.0</jackson-dataformat-yaml.version>
         <jakarta.ws.rs-api.version>3.1.0</jakarta.ws.rs-api.version>
         <slf4j.version>2.0.17</slf4j.version>
         <log4j.version>2.25.3</log4j.version>
-        <protoc-version>3.25.5</protoc-version>
+        <protoc.version>3.25.5</protoc.version>
         <grpc.version>1.79.0</grpc.version>
-        <protoc-gen-grpc-java>1.72.0</protoc-gen-grpc-java>
+        <protoc-gen-grpc-java.version>1.72.0</protoc-gen-grpc-java.version>
         <annotations-api.version>6.0.53</annotations-api.version>
         <junit-jupiter.version>5.13.4</junit-jupiter.version>
         <oauth2-oidc-sdk.version>11.33</oauth2-oidc-sdk.version>
         <langchain4j.version>1.11.0</langchain4j.version>
         <mockito.version>5.21.0</mockito.version>
-        <jacoco-maven-plugin.version>0.8.14</jacoco-maven-plugin.version>
-        <spotless-maven-plugin.version>3.2.1</spotless-maven-plugin.version>
-        <palantir-format-version.version>2.71.0</palantir-format-version.version>
+        <palantir-java-format.version>2.71.0</palantir-java-format.version>
     </properties>
 
     <dependencyManagement>
@@ -113,6 +113,16 @@
         <pluginManagement>
             <plugins>
                 <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-failsafe-plugin</artifactId>
+                    <version>${maven-failsafe-plugin.version}</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-source-plugin</artifactId>
+                    <version>${maven-source-plugin.version}</version>
+                </plugin>
+                <plugin>
                     <groupId>org.jacoco</groupId>
                     <artifactId>jacoco-maven-plugin</artifactId>
                     <version>${jacoco-maven-plugin.version}</version>
@@ -124,7 +134,7 @@
                     <configuration>
                         <java>
                             <palantirJavaFormat>
-                                <version>${palantir-format-version.version}</version>
+                                <version>${palantir-java-format.version}</version>
                             </palantirJavaFormat>
                             <removeUnusedImports />
                             <formatAnnotations />

--- a/capabilities-runtimes/capabilities-runtimes-camel/capabilities-runtimes-camel-plugin/pom.xml
+++ b/capabilities-runtimes/capabilities-runtimes-camel/capabilities-runtimes-camel-plugin/pom.xml
@@ -82,7 +82,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>3.5.5</version>
                 <executions>
                     <execution>
                         <goals>

--- a/pom.xml
+++ b/pom.xml
@@ -17,8 +17,10 @@
         <maven.compiler.target>21</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
+        <jacoco-maven-plugin.version>0.8.14</jacoco-maven-plugin.version>
         <maven-gpg-plugin.version>3.2.8</maven-gpg-plugin.version>
         <maven-javadoc-plugin.version>3.12.0</maven-javadoc-plugin.version>
+        <maven-source-plugin.version>3.4.0</maven-source-plugin.version>
         <central-publishing-maven-plugin.version>0.10.0</central-publishing-maven-plugin.version>
         <maven-release-plugin.version>3.1.1</maven-release-plugin.version>
         <maven-scm-plugin.version>2.1.0</maven-scm-plugin.version>
@@ -82,9 +84,6 @@
     <profiles>
         <profile>
             <id>coverage</id>
-            <properties>
-                <jacoco-maven-plugin.version>0.8.14</jacoco-maven-plugin.version>
-            </properties>
             <build>
                 <plugins>
                     <plugin>
@@ -127,6 +126,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-source-plugin</artifactId>
+                        <version>${maven-source-plugin.version}</version>
                         <executions>
                             <execution>
                                 <id>attach-sources</id>


### PR DESCRIPTION
## Summary
- Add missing version for `maven-source-plugin` (3.4.0) in root POM and capabilities-exchange
- Extract hardcoded `os-maven-plugin` (1.7.1) and `maven-failsafe-plugin` (3.5.5) versions into properties in capabilities-parent
- Remove duplicate `jackson-dataformat-yaml.version` property in capabilities-parent
- Move `jacoco-maven-plugin.version` from coverage profile to root POM main properties to eliminate duplication with capabilities-parent
- Standardize property naming: `protoc-version` -> `protoc.version`, `protoc-gen-grpc-java` -> `protoc-gen-grpc-java.version`, `palantir-format-version.version` -> `palantir-java-format.version`
- Add `maven-failsafe-plugin` and `maven-source-plugin` to pluginManagement in capabilities-parent
- Reorganize properties: plugin versions grouped separately from dependency versions

## Test plan
- [x] Full `mvn verify` passes (all 21 code modules succeed; archetype IT failure is pre-existing on main)