### PR TITLE
Fix #863: add ProcessRunner utility to capabilities-common

### DIFF
--- a/capabilities-common/src/main/java/ai/wanaku/capabilities/sdk/common/ProcessRunner.java
+++ b/capabilities-common/src/main/java/ai/wanaku/capabilities/sdk/common/ProcessRunner.java
@@ -1,0 +1,102 @@
+package ai.wanaku.capabilities.sdk.common;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import ai.wanaku.capabilities.sdk.api.exceptions.WanakuException;
+
+/**
+ * Convenience utility for running external processes. This is intended for use by capabilities and CLI code.
+ * It MUST NOT be used in router code.
+ */
+public class ProcessRunner {
+    private static final Logger LOG = LoggerFactory.getLogger(ProcessRunner.class);
+
+    private ProcessRunner() {}
+
+    public static String runWithOutput(String... command) {
+        try {
+            ProcessBuilder processBuilder = new ProcessBuilder(command);
+            // Redirect output and error streams to a pipe
+            processBuilder.redirectOutput(ProcessBuilder.Redirect.PIPE);
+            processBuilder.redirectError(ProcessBuilder.Redirect.PIPE);
+
+            final Process process = processBuilder.start();
+            LOG.info("Waiting for process to finish...");
+
+            String output = readOutput(process);
+
+            waitForExit(process);
+            return output;
+        } catch (IOException e) {
+            LOG.error("I/O Error: {}", e.getMessage(), e);
+            throw new WanakuException(e);
+        } catch (InterruptedException e) {
+            LOG.error("Interrupted: {}", e.getMessage(), e);
+            throw new WanakuException(e);
+        }
+    }
+
+    private static String readOutput(Process process) throws IOException {
+        // Read the output from the process
+        BufferedReader reader = new BufferedReader(new InputStreamReader(process.getInputStream()));
+        StringBuilder output = new StringBuilder();
+        String line;
+        while ((line = reader.readLine()) != null) {
+            output.append(line).append("\n");
+        }
+        return output.toString();
+    }
+
+    public static void run(File directory, String... command) {
+        run(directory, null, command);
+    }
+
+    public static void run(File directory, Map<String, String> environmentVariables, String... command) {
+        try {
+            LOG.info("About to run command: {}", String.join(" ", command));
+            ProcessBuilder processBuilder = new ProcessBuilder();
+            processBuilder.command(command).inheritIO().directory(directory);
+
+            if (environmentVariables != null) {
+                processBuilder.environment().putAll(environmentVariables);
+            }
+
+            final Process process = processBuilder.start();
+
+            LOG.info("Waiting for process to finish...");
+            waitForExit(process);
+        } catch (IOException e) {
+            LOG.error("I/O Error: {}", e.getMessage(), e);
+            throw new WanakuException(e);
+        } catch (InterruptedException e) {
+            LOG.error("Interrupted: {}", e.getMessage(), e);
+            throw new WanakuException(e);
+        }
+    }
+
+    private static void waitForExit(Process process) throws InterruptedException {
+        Thread thread = new Thread(() -> {
+            if (process.isAlive()) {
+                process.destroy();
+            }
+        });
+
+        try {
+            Runtime.getRuntime().addShutdownHook(thread);
+
+            final int ret = process.waitFor();
+            if (ret != 0) {
+                LOG.warn("Process did not execute successfully: (return status {})", ret);
+            }
+        } finally {
+            if (!process.isAlive()) {
+                Runtime.getRuntime().removeShutdownHook(thread);
+            }
+        }
+    }
+}

--- a/capabilities-common/src/test/java/ai/wanaku/capabilities/sdk/common/ProcessRunnerTest.java
+++ b/capabilities-common/src/test/java/ai/wanaku/capabilities/sdk/common/ProcessRunnerTest.java
@@ -1,0 +1,18 @@
+package ai.wanaku.capabilities.sdk.common;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class ProcessRunnerTest {
+
+    @Test
+    void runWithOutput_returnsCommandOutput() {
+        String output = ProcessRunner.runWithOutput("echo", "hello");
+
+        assertNotNull(output, "Output should not be null");
+        assertFalse(output.isEmpty(), "Output should not be empty");
+        assertTrue(output.contains("hello"), "Output should contain 'hello'");
+    }
+}


### PR DESCRIPTION
## Summary
- Add `ProcessRunner` utility class to `capabilities-common` module (moved from wanaku `core-util`)
- Uses SLF4J logging instead of JBoss Logger
- Add unit test for `runWithOutput()`

## Test plan
- [x] `mvn verify` passes
- [x] Unit test for `runWithOutput()` passes

## Summary by Sourcery

Introduce a reusable ProcessRunner utility in capabilities-common for executing external processes and capturing their output.

New Features:
- Add ProcessRunner utility class to capabilities-common for running external processes with optional working directory and environment variables.
- Provide runWithOutput helper to execute a command and return its combined output as a string.

Tests:
- Add a unit test validating that runWithOutput returns non-empty output containing the expected content.