### PR TITLE
chore: address ProcessRunner review comments from PR #89

### DIFF
--- a/capabilities-common/src/main/java/ai/wanaku/capabilities/sdk/common/ProcessRunner.java
+++ b/capabilities-common/src/main/java/ai/wanaku/capabilities/sdk/common/ProcessRunner.java
@@ -4,6 +4,7 @@ import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -42,7 +43,8 @@ public class ProcessRunner {
     }
 
     private static String readOutput(Process process) throws IOException {
-        try (BufferedReader reader = new BufferedReader(new InputStreamReader(process.getInputStream()))) {
+        try (BufferedReader reader =
+                new BufferedReader(new InputStreamReader(process.getInputStream(), StandardCharsets.UTF_8))) {
             StringBuilder output = new StringBuilder();
             String line;
             while ((line = reader.readLine()) != null) {

--- a/capabilities-common/src/test/java/ai/wanaku/capabilities/sdk/common/ProcessRunnerTest.java
+++ b/capabilities-common/src/test/java/ai/wanaku/capabilities/sdk/common/ProcessRunnerTest.java
@@ -8,18 +8,17 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ProcessRunnerTest {
 
-    private static boolean isWindows() {
-        return System.getProperty("os.name").toLowerCase().contains("win");
+    private static String[] shellCommand(String script) {
+        if (System.getProperty("os.name").toLowerCase().contains("win")) {
+            return new String[] {"cmd.exe", "/c", script};
+        } else {
+            return new String[] {"sh", "-c", script};
+        }
     }
 
     @Test
     void runWithOutput_returnsCommandOutput() {
-        String output;
-        if (isWindows()) {
-            output = ProcessRunner.runWithOutput("cmd.exe", "/c", "echo hello");
-        } else {
-            output = ProcessRunner.runWithOutput("sh", "-c", "echo hello");
-        }
+        String output = ProcessRunner.runWithOutput(shellCommand("echo hello"));
 
         assertNotNull(output, "Output should not be null");
         assertFalse(output.isEmpty(), "Output should not be empty");
@@ -28,12 +27,8 @@ public class ProcessRunnerTest {
 
     @Test
     void runWithOutput_nonZeroExitDoesNotThrow() {
-        String output;
-        if (isWindows()) {
-            output = assertDoesNotThrow(() -> ProcessRunner.runWithOutput("cmd.exe", "/c", "echo output && exit /b 1"));
-        } else {
-            output = assertDoesNotThrow(() -> ProcessRunner.runWithOutput("sh", "-c", "echo output; exit 1"));
-        }
+        String[] command = shellCommand("echo output; exit 1");
+        String output = assertDoesNotThrow(() -> ProcessRunner.runWithOutput(command));
 
         assertNotNull(output, "Output should not be null");
         assertTrue(output.contains("output"), "Output should contain 'output'");
@@ -41,12 +36,7 @@ public class ProcessRunnerTest {
 
     @Test
     void runWithOutput_capturesStderrViaMergedStream() {
-        String output;
-        if (isWindows()) {
-            output = ProcessRunner.runWithOutput("cmd.exe", "/c", "echo stdout && echo stderr 1>&2");
-        } else {
-            output = ProcessRunner.runWithOutput("sh", "-c", "echo stdout && echo stderr 1>&2");
-        }
+        String output = ProcessRunner.runWithOutput(shellCommand("echo stdout && echo stderr 1>&2"));
 
         assertNotNull(output, "Output should not be null");
         assertFalse(output.isEmpty(), "Output should not be empty");


### PR DESCRIPTION
## Summary
- Use `redirectErrorStream(true)` to merge stderr into stdout, preventing deadlock when subprocess writes heavily to stderr
- Use try-with-resources for `BufferedReader` in `readOutput` to prevent resource leaks
- Restore interrupt status via `Thread.currentThread().interrupt()` before rethrowing `WanakuException` on `InterruptedException`
- Make tests cross-platform with OS detection helper
- Add test for non-zero exit status (verifies no exception is thrown)
- Add test for merged stderr/stdout stream behavior

## Test plan
- [x] `mvn verify` passes
- [x] All three `ProcessRunnerTest` tests pass

## Summary by Sourcery

Improve ProcessRunner robustness and portability while expanding its test coverage.

Bug Fixes:
- Prevent potential deadlock and lost error output by merging the subprocess stderr into stdout in ProcessRunner.
- Preserve thread interrupt status when handling InterruptedException in ProcessRunner run methods.

Enhancements:
- Use try-with-resources when reading process output to avoid leaking IO resources in ProcessRunner.

Tests:
- Make ProcessRunner tests OS-agnostic by using platform-specific command invocations.
- Add tests to verify non-zero exit codes do not throw exceptions and that stderr is captured via the merged output stream.