### PR TITLE
Fix wanaku-ai/wanaku#873: add AUTH_PREFIX for secure token propagation

### DIFF
--- a/capabilities-api/src/main/java/ai/wanaku/capabilities/sdk/api/util/ReservedArgumentNames.java
+++ b/capabilities-api/src/main/java/ai/wanaku/capabilities/sdk/api/util/ReservedArgumentNames.java
@@ -49,5 +49,20 @@ public final class ReservedArgumentNames {
      */
     public static final String METADATA_PREFIX = "wanaku_meta_";
 
+    /**
+     * Prefix for authentication arguments that should be converted to headers.
+     * <p>
+     * Arguments with this prefix (e.g., {@code wanaku_auth_Authorization}) are extracted
+     * from the regular arguments, the prefix is stripped, and the remaining name
+     * becomes the header name (e.g., {@code Authorization}).
+     * <p>
+     * Unlike {@link #METADATA_PREFIX}, authentication arguments are treated as sensitive:
+     * they are never exposed to LLMs, and are always redacted in logs and observability events.
+     * <p>
+     * These arguments are intended to be set by MCP clients (not by LLMs) to propagate
+     * access tokens or other credentials to downstream capabilities.
+     */
+    public static final String AUTH_PREFIX = "wanaku_auth_";
+
     private ReservedArgumentNames() {}
 }


### PR DESCRIPTION
## Summary
- Add `AUTH_PREFIX = "wanaku_auth_"` constant to `ReservedArgumentNames` for secure access token propagation from MCP clients to downstream capabilities
- Auth-prefixed arguments are treated as sensitive: never exposed to LLMs, always redacted in logs/events

## Related
- Part of wanaku-ai/wanaku#873
- Companion PR in wanaku-ai/wanaku implements the extraction, filtering, and redaction logic

## Test plan
- [ ] Verify constant is accessible from consuming projects
- [ ] Companion PR in wanaku includes full test coverage

## Summary by Sourcery

New Features:
- Add AUTH_PREFIX constant to ReservedArgumentNames to identify authentication arguments that should be converted to headers and treated as sensitive.