### PR TITLE
Bugfix: copying namespace from RemoteToolReference

### DIFF
--- a/capabilities-api/src/main/java/ai/wanaku/capabilities/sdk/api/types/RemoteToolReference.java
+++ b/capabilities-api/src/main/java/ai/wanaku/capabilities/sdk/api/types/RemoteToolReference.java
@@ -165,7 +165,7 @@ public class RemoteToolReference extends LabelsAwareEntity<String> implements Ca
         ret.setType(ref.getType());
         ret.setUri("<remote>");
         ret.setId(ref.getId());
-
+        ret.setNamespace(ref.getNamespace());
         return ret;
     }
 


### PR DESCRIPTION
When I add a new Forward to namespace _public_ (assuming I've fixed forward namespaces in the first place: https://github.com/wanaku-ai/wanaku/pull/989), on Tools page, it is still listed *without* any namespace.

I believe this helps. Remote tools have the namespace saved correctly, it is just lost during the conversion.

## Summary by Sourcery

Bug Fixes:
- Ensure the namespace from a RemoteToolReference is copied to the resulting ToolReference during conversion.