### PR TITLE
Add support for authentication-less capabilities

### DIFF
--- a/capabilities-common/src/main/java/ai/wanaku/capabilities/sdk/common/security/SecurityServiceConfig.java
+++ b/capabilities-common/src/main/java/ai/wanaku/capabilities/sdk/common/security/SecurityServiceConfig.java
@@ -25,4 +25,19 @@ public interface SecurityServiceConfig {
      * @return The OpenID Connect token endpoint as a {@code String}.
      */
     String getTokenEndpoint();
+
+    /**
+     * Returns whether authentication is enabled. Authentication is considered enabled
+     * when client ID, secret, and token endpoint are all non-null and non-empty.
+     *
+     * @return {@code true} if authentication is enabled, {@code false} otherwise.
+     */
+    default boolean isAuthEnabled() {
+        return getClientId() != null
+                && !getClientId().isEmpty()
+                && getSecret() != null
+                && !getSecret().isEmpty()
+                && getTokenEndpoint() != null
+                && !getTokenEndpoint().isEmpty();
+    }
 }

--- a/capabilities-discovery/src/main/java/ai/wanaku/capabilities/sdk/discovery/DiscoveryServiceHttpClient.java
+++ b/capabilities-discovery/src/main/java/ai/wanaku/capabilities/sdk/discovery/DiscoveryServiceHttpClient.java
@@ -44,7 +44,7 @@ public class DiscoveryServiceHttpClient {
         this.baseUrl = sanitize(config);
         this.serializer = config.getSerializer();
 
-        serviceAuthenticator = new ServiceAuthenticator(config);
+        serviceAuthenticator = config.isAuthEnabled() ? new ServiceAuthenticator(config) : null;
     }
 
     /**
@@ -58,6 +58,19 @@ public class DiscoveryServiceHttpClient {
         return config.getBaseUrl() != null && config.getBaseUrl().endsWith("/")
                 ? config.getBaseUrl().substring(0, config.getBaseUrl().length() - 1)
                 : config.getBaseUrl();
+    }
+
+    /**
+     * Adds the Authorization header to the request builder if authentication is enabled.
+     *
+     * @param builder The HTTP request builder to add the header to.
+     * @return The builder with the Authorization header added if applicable.
+     */
+    private HttpRequest.Builder withAuth(HttpRequest.Builder builder) {
+        if (serviceAuthenticator != null) {
+            builder.header("Authorization", serviceAuthenticator.toHeaderValue());
+        }
+        return builder;
     }
 
     /**
@@ -75,11 +88,10 @@ public class DiscoveryServiceHttpClient {
             String jsonRequestBody = serializer.serialize(serviceTarget);
             URI uri = URI.create(this.baseUrl + this.serviceBasePath + operationPath);
 
-            HttpRequest request = HttpRequest.newBuilder()
-                    .uri(uri)
-                    .header("Content-Type", MediaType.APPLICATION_JSON)
-                    .header("Accept", MediaType.WILDCARD)
-                    .header("Authorization", serviceAuthenticator.toHeaderValue())
+            HttpRequest request = withAuth(HttpRequest.newBuilder()
+                            .uri(uri)
+                            .header("Content-Type", MediaType.APPLICATION_JSON)
+                            .header("Accept", MediaType.WILDCARD))
                     .method(httpMethod, HttpRequest.BodyPublishers.ofString(jsonRequestBody))
                     .build();
 
@@ -126,9 +138,7 @@ public class DiscoveryServiceHttpClient {
         try {
             URI uri = URI.create(this.baseUrl + this.serviceBasePath + "/heartbeats");
 
-            HttpRequest request = HttpRequest.newBuilder()
-                    .uri(uri)
-                    .header("Authorization", serviceAuthenticator.toHeaderValue())
+            HttpRequest request = withAuth(HttpRequest.newBuilder().uri(uri))
                     .POST(HttpRequest.BodyPublishers.ofString(id))
                     .build();
 
@@ -151,11 +161,10 @@ public class DiscoveryServiceHttpClient {
             String jsonRequestBody = serializer.serialize(serviceState);
             URI uri = URI.create(this.baseUrl + this.serviceBasePath + "/update/" + id);
 
-            HttpRequest request = HttpRequest.newBuilder()
-                    .uri(uri)
-                    .header("Content-Type", MediaType.APPLICATION_JSON)
-                    .header("Accept", MediaType.WILDCARD)
-                    .header("Authorization", serviceAuthenticator.toHeaderValue())
+            HttpRequest request = withAuth(HttpRequest.newBuilder()
+                            .uri(uri)
+                            .header("Content-Type", MediaType.APPLICATION_JSON)
+                            .header("Accept", MediaType.WILDCARD))
                     .POST(HttpRequest.BodyPublishers.ofString(jsonRequestBody))
                     .build();
 

--- a/capabilities-discovery/src/test/java/ai/wanaku/capabilities/sdk/discovery/DiscoveryServiceHttpClientTest.java
+++ b/capabilities-discovery/src/test/java/ai/wanaku/capabilities/sdk/discovery/DiscoveryServiceHttpClientTest.java
@@ -137,4 +137,53 @@ class DiscoveryServiceHttpClientTest {
         assertEquals(
                 "/api/v1/management/discovery/heartbeats", requests.getFirst().path());
     }
+
+    // ==================== No-Auth Tests ====================
+
+    @Test
+    void noAuthClientCanRegister() throws IOException {
+        HttpServer noAuthServer = HttpServer.create(new InetSocketAddress(0), 0);
+        int noAuthPort = noAuthServer.getAddress().getPort();
+        String noAuthBaseUrl = "http://localhost:" + noAuthPort;
+        List<RequestRecord> noAuthRequests = new CopyOnWriteArrayList<>();
+
+        noAuthServer.createContext("/api/v1/management/discovery", exchange -> {
+            String body = new String(exchange.getRequestBody().readAllBytes());
+            noAuthRequests.add(new RequestRecord(
+                    exchange.getRequestMethod(), exchange.getRequestURI().getPath(), body));
+
+            String response = "{\"data\":{\"id\":\"test-id\",\"serviceName\":\"test\"}}";
+            exchange.getResponseHeaders().set("Content-Type", "application/json");
+            exchange.sendResponseHeaders(200, response.length());
+            try (OutputStream os = exchange.getResponseBody()) {
+                os.write(response.getBytes());
+            }
+        });
+
+        noAuthServer.start();
+
+        try {
+            DefaultServiceConfig noAuthConfig = DefaultServiceConfig.Builder.newBuilder()
+                    .baseUrl(noAuthBaseUrl)
+                    .serializer(new JacksonSerializer())
+                    .build();
+
+            DiscoveryServiceHttpClient noAuthClient = new DiscoveryServiceHttpClient(noAuthConfig);
+            ServiceTarget target = ServiceTarget.newEmptyTarget("test-service", "localhost", 9090, "tool-invoker");
+
+            HttpResponse<String> response = noAuthClient.register(target);
+
+            assertNotNull(response);
+            assertEquals(200, response.statusCode());
+            assertEquals(1, noAuthRequests.size());
+            assertEquals("POST", noAuthRequests.getFirst().method());
+            assertEquals(
+                    "/api/v1/management/discovery", noAuthRequests.getFirst().path());
+
+            String body = noAuthRequests.getFirst().body();
+            assertTrue(body.contains("\"serviceName\":\"test-service\""), "Body should contain serviceName");
+        } finally {
+            noAuthServer.stop(0);
+        }
+    }
 }

--- a/capabilities-runtimes/capabilities-runtimes-camel/capabilities-runtimes-camel-plugin/src/main/java/ai/wanaku/capabilities/sdk/runtime/camel/plugin/PluginConfiguration.java
+++ b/capabilities-runtimes/capabilities-runtimes-camel/capabilities-runtimes-camel-plugin/src/main/java/ai/wanaku/capabilities/sdk/runtime/camel/plugin/PluginConfiguration.java
@@ -113,10 +113,10 @@ public class PluginConfiguration {
             LOG.info("No routes or routes ref found, using builtin routes from the current integration application");
         }
         if (clientId == null || clientId.isEmpty()) {
-            throw new IllegalStateException("client.id (or CLIENT_ID env var) is required");
+            LOG.info("No client ID configured, running without authentication");
         }
         if (clientSecret == null || clientSecret.isEmpty()) {
-            throw new IllegalStateException("client.secret (or CLIENT_SECRET env var) is required");
+            LOG.info("No client secret configured, running without authentication");
         }
     }
 

--- a/capabilities-services-client/src/main/java/ai/wanaku/capabilities/sdk/services/ServicesHttpClient.java
+++ b/capabilities-services-client/src/main/java/ai/wanaku/capabilities/sdk/services/ServicesHttpClient.java
@@ -63,7 +63,7 @@ public class ServicesHttpClient {
         this.baseUrl = sanitize(config);
         this.serializer = config.getSerializer();
         this.objectMapper = new ObjectMapper();
-        this.serviceAuthenticator = new ServiceAuthenticator(config);
+        this.serviceAuthenticator = config.isAuthEnabled() ? new ServiceAuthenticator(config) : null;
     }
 
     /**
@@ -76,6 +76,19 @@ public class ServicesHttpClient {
         return config.getBaseUrl() != null && config.getBaseUrl().endsWith("/")
                 ? config.getBaseUrl().substring(0, config.getBaseUrl().length() - 1)
                 : config.getBaseUrl();
+    }
+
+    /**
+     * Adds the Authorization header to the request builder if authentication is enabled.
+     *
+     * @param builder The HTTP request builder to add the header to.
+     * @return The builder with the Authorization header added if applicable.
+     */
+    private HttpRequest.Builder withAuth(HttpRequest.Builder builder) {
+        if (serviceAuthenticator != null) {
+            builder.header("Authorization", serviceAuthenticator.toHeaderValue());
+        }
+        return builder;
     }
 
     /**
@@ -94,11 +107,10 @@ public class ServicesHttpClient {
             String jsonRequestBody = serializer.serialize(payload);
             URI uri = URI.create(this.baseUrl + path);
 
-            HttpRequest request = HttpRequest.newBuilder()
-                    .uri(uri)
-                    .header("Content-Type", MediaType.APPLICATION_JSON)
-                    .header("Accept", MediaType.APPLICATION_JSON)
-                    .header("Authorization", serviceAuthenticator.toHeaderValue())
+            HttpRequest request = withAuth(HttpRequest.newBuilder()
+                            .uri(uri)
+                            .header("Content-Type", MediaType.APPLICATION_JSON)
+                            .header("Accept", MediaType.APPLICATION_JSON))
                     .POST(HttpRequest.BodyPublishers.ofString(jsonRequestBody))
                     .build();
 
@@ -133,11 +145,10 @@ public class ServicesHttpClient {
             String jsonRequestBody = serializer.serialize(payload);
             URI uri = URI.create(this.baseUrl + path);
 
-            HttpRequest request = HttpRequest.newBuilder()
-                    .uri(uri)
-                    .header("Content-Type", MediaType.APPLICATION_JSON)
-                    .header("Accept", MediaType.APPLICATION_JSON)
-                    .header("Authorization", serviceAuthenticator.toHeaderValue())
+            HttpRequest request = withAuth(HttpRequest.newBuilder()
+                            .uri(uri)
+                            .header("Content-Type", MediaType.APPLICATION_JSON)
+                            .header("Accept", MediaType.APPLICATION_JSON))
                     .PUT(HttpRequest.BodyPublishers.ofString(jsonRequestBody))
                     .build();
 
@@ -170,10 +181,8 @@ public class ServicesHttpClient {
         try {
             URI uri = URI.create(this.baseUrl + path);
 
-            HttpRequest request = HttpRequest.newBuilder()
-                    .uri(uri)
-                    .header("Accept", MediaType.APPLICATION_JSON)
-                    .header("Authorization", serviceAuthenticator.toHeaderValue())
+            HttpRequest request = withAuth(
+                            HttpRequest.newBuilder().uri(uri).header("Accept", MediaType.APPLICATION_JSON))
                     .GET()
                     .build();
 
@@ -205,10 +214,8 @@ public class ServicesHttpClient {
         try {
             URI uri = URI.create(this.baseUrl + path);
 
-            HttpRequest request = HttpRequest.newBuilder()
-                    .uri(uri)
-                    .header("Accept", MediaType.APPLICATION_JSON)
-                    .header("Authorization", serviceAuthenticator.toHeaderValue())
+            HttpRequest request = withAuth(
+                            HttpRequest.newBuilder().uri(uri).header("Accept", MediaType.APPLICATION_JSON))
                     .DELETE()
                     .build();
 
@@ -550,10 +557,7 @@ public class ServicesHttpClient {
         System.out.println("Reading from path " + this.baseUrl + path);
         URI uri = URI.create(this.baseUrl + path);
 
-        HttpRequest request = HttpRequest.newBuilder()
-                .uri(uri)
-                .header("Accept", "text/event-stream")
-                .header("Authorization", serviceAuthenticator.toHeaderValue())
+        HttpRequest request = withAuth(HttpRequest.newBuilder().uri(uri).header("Accept", "text/event-stream"))
                 .GET()
                 .build();
 

--- a/capabilities-services-client/src/test/java/ai/wanaku/capabilities/sdk/services/ServicesHttpClientTest.java
+++ b/capabilities-services-client/src/test/java/ai/wanaku/capabilities/sdk/services/ServicesHttpClientTest.java
@@ -301,4 +301,45 @@ class ServicesHttpClientTest {
         assertEquals("DELETE", requests.getFirst().method());
         assertEquals("/api/v1/data-store?name=my-store", requests.getFirst().path());
     }
+
+    // ==================== No-Auth Tests ====================
+
+    @Test
+    void noAuthClientCanListTools() throws IOException {
+        HttpServer noAuthServer = HttpServer.create(new InetSocketAddress(0), 0);
+        int noAuthPort = noAuthServer.getAddress().getPort();
+        String noAuthBaseUrl = "http://localhost:" + noAuthPort;
+        List<RequestRecord> noAuthRequests = new CopyOnWriteArrayList<>();
+
+        noAuthServer.createContext("/api/", exchange -> {
+            String body = new String(exchange.getRequestBody().readAllBytes());
+            noAuthRequests.add(new RequestRecord(
+                    exchange.getRequestMethod(), exchange.getRequestURI().getPath(), body));
+
+            String response = "{\"data\":null}";
+            exchange.getResponseHeaders().set("Content-Type", "application/json");
+            exchange.sendResponseHeaders(200, response.length());
+            try (OutputStream os = exchange.getResponseBody()) {
+                os.write(response.getBytes());
+            }
+        });
+
+        noAuthServer.start();
+
+        try {
+            DefaultServiceConfig noAuthConfig = DefaultServiceConfig.Builder.newBuilder()
+                    .baseUrl(noAuthBaseUrl)
+                    .serializer(new JacksonSerializer())
+                    .build();
+
+            ServicesHttpClient noAuthClient = new ServicesHttpClient(noAuthConfig);
+            noAuthClient.listTools();
+
+            assertEquals(1, noAuthRequests.size());
+            assertEquals("GET", noAuthRequests.getFirst().method());
+            assertEquals("/api/v1/tools", noAuthRequests.getFirst().path());
+        } finally {
+            noAuthServer.stop(0);
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- Add `isAuthEnabled()` default method to `SecurityServiceConfig` that checks if OAuth2 credentials are configured
- Make `ServiceAuthenticator` nullable in `ServicesHttpClient` and `DiscoveryServiceHttpClient`, skipping the `Authorization` header when auth is disabled
- Relax `PluginConfiguration.validate()` to log info instead of failing when `clientId`/`clientSecret` are missing
- Add no-auth integration tests for both HTTP clients

Aligns with wanaku-ai/wanaku#984 (noauth profile support).

## Test plan
- [x] Existing authenticated tests pass (OIDC mock server still used)
- [x] New `noAuthClientCanListTools` test verifies `ServicesHttpClient` works without credentials
- [x] New `noAuthClientCanRegister` test verifies `DiscoveryServiceHttpClient` works without credentials
- [x] Full `mvn verify` passes

## Summary by Sourcery

Allow capabilities HTTP clients and Camel plugin to operate without authentication when OAuth credentials are not configured.

New Features:
- Add an isAuthEnabled() helper on SecurityServiceConfig to detect when OAuth2 authentication should be used.
- Allow ServicesHttpClient and DiscoveryServiceHttpClient to be constructed without authentication and omit Authorization headers when auth is disabled.

Enhancements:
- Relax PluginConfiguration validation to log and run without authentication when client ID or client secret are missing.

Tests:
- Add no-auth integration-style tests for ServicesHttpClient and DiscoveryServiceHttpClient to verify they work without credentials.