### PR TITLE
chore: make HTTP 404 retryable during resource downloads

### DIFF
--- a/capabilities-runtimes/capabilities-runtimes-camel/capabilities-runtimes-camel-common/src/main/java/ai/wanaku/capabilities/sdk/runtime/camel/downloader/ExponentialBackoffRetryPolicy.java
+++ b/capabilities-runtimes/capabilities-runtimes-camel/capabilities-runtimes-camel-common/src/main/java/ai/wanaku/capabilities/sdk/runtime/camel/downloader/ExponentialBackoffRetryPolicy.java
@@ -28,7 +28,11 @@ public class ExponentialBackoffRetryPolicy implements RetryPolicy {
     public boolean isRetryable(Exception e) {
         if (e instanceof WanakuWebException wex) {
             int status = wex.getStatusCode();
-            // Do not retry client errors (4xx)
+            // Retry 404 because resources may not be available yet at startup
+            if (status == 404) {
+                return true;
+            }
+            // Do not retry other client errors (4xx)
             return status >= 500;
         }
 


### PR DESCRIPTION
## Summary
- HTTP 404 responses during resource downloads are now retried with exponential backoff instead of being treated as a permanent failure.
- When a capability pod starts before the datastore is populated, resources return 404 temporarily. Previously this caused the pod to exit immediately, entering a CrashLoopBackOff cycle despite the retry policy being configured.

## Test plan
- [ ] Deploy a capability pod that references datastore resources not yet available
- [ ] Verify download retries occur with exponential backoff on 404 responses
- [ ] Verify non-404 client errors (e.g., 400, 403) still fail immediately without retries

## Summary by Sourcery

Bug Fixes:
- Prevent capability pods from exiting and entering CrashLoopBackOff when datastore-backed resources temporarily return HTTP 404 at startup by retrying those downloads.