### PR TITLE
Fix #86: support configurable Keycloak realm in token endpoint construction

### DIFF
--- a/capabilities-security/src/main/java/ai/wanaku/capabilities/sdk/security/TokenEndpoint.java
+++ b/capabilities-security/src/main/java/ai/wanaku/capabilities/sdk/security/TokenEndpoint.java
@@ -49,7 +49,7 @@ public final class TokenEndpoint {
      */
     public static String autoResolve(String registrationUri, String tokenEndpointUri) {
         if (tokenEndpointUri != null) {
-            if (!tokenEndpointUri.isEmpty() && !tokenEndpointUri.endsWith("/realms/wanaku/")) {
+            if (!tokenEndpointUri.isEmpty() && !tokenEndpointUri.matches(".*/realms/[^/]+/?$")) {
                 return direct(tokenEndpointUri);
             }
 

--- a/capabilities-security/src/test/java/ai/wanaku/capabilities/sdk/security/TokenEndpointTest.java
+++ b/capabilities-security/src/test/java/ai/wanaku/capabilities/sdk/security/TokenEndpointTest.java
@@ -49,6 +49,28 @@ class TokenEndpointTest {
     }
 
     @Test
+    void autoResolveUsesFromBaseUrlWhenTokenEndpointEndsWithCustomRealm() {
+        String registrationUri = "https://service.example.com";
+        String tokenEndpointUri = "https://auth.example.com/realms/my-custom-realm/";
+
+        String result = TokenEndpoint.autoResolve(registrationUri, tokenEndpointUri);
+        String expected = "https://auth.example.com/realms/my-custom-realm//protocol/openid-connect/token";
+
+        assertEquals(expected, result);
+    }
+
+    @Test
+    void autoResolveUsesFromBaseUrlWhenTokenEndpointEndsWithRealmNoTrailingSlash() {
+        String registrationUri = "https://service.example.com";
+        String tokenEndpointUri = "https://auth.example.com/realms/production";
+
+        String result = TokenEndpoint.autoResolve(registrationUri, tokenEndpointUri);
+        String expected = "https://auth.example.com/realms/production/protocol/openid-connect/token";
+
+        assertEquals(expected, result);
+    }
+
+    @Test
     void autoResolveUsesFromBaseUrlWhenTokenEndpointIsEmpty() {
         String registrationUri = "https://service.example.com";
         String tokenEndpointUri = "";


### PR DESCRIPTION
## Summary

- Replace hardcoded `/realms/wanaku/` check in `TokenEndpoint.autoResolve()` with a regex pattern `.*/realms/[^/]+/?$` that matches any realm name
- Add tests for custom realm names and realm URLs without trailing slash

## Test plan

- [x] Existing tests pass (9/9)
- [x] New test: custom realm name (`my-custom-realm`) is correctly detected and OIDC path appended
- [x] New test: realm URL without trailing slash (`/realms/production`) is correctly detected

## Summary by Sourcery

Allow TokenEndpoint.autoResolve to work with configurable Keycloak realms instead of a single hardcoded realm.

Bug Fixes:
- Fix token endpoint auto-resolution so that any Keycloak realm path is accepted rather than only `/realms/wanaku/`.

Tests:
- Add tests covering custom realm names and realm URLs without trailing slashes in token endpoint auto-resolution.