### PR TITLE
Fix #120: strip token endpoint path before OIDC discovery

### DIFF
--- a/capabilities-security/src/main/java/ai/wanaku/capabilities/sdk/security/ServiceAuthenticator.java
+++ b/capabilities-security/src/main/java/ai/wanaku/capabilities/sdk/security/ServiceAuthenticator.java
@@ -95,8 +95,8 @@ public class ServiceAuthenticator {
      * need.
      */
     private static Issuer resolveIssuer(SecurityServiceConfig config) {
-        // The OpenID provider issuer URL
-        Issuer issuer = new Issuer(config.getTokenEndpoint());
+        // The OpenID provider issuer URL — strip the token endpoint path to get the realm URL
+        Issuer issuer = new Issuer(TokenEndpoint.toRealmUrl(config.getTokenEndpoint()));
 
         try {
             final URL openIdConfigUrl = OIDCProviderMetadata.resolveURL(issuer);

--- a/capabilities-security/src/main/java/ai/wanaku/capabilities/sdk/security/TokenEndpoint.java
+++ b/capabilities-security/src/main/java/ai/wanaku/capabilities/sdk/security/TokenEndpoint.java
@@ -41,6 +41,22 @@ public final class TokenEndpoint {
         return baseUrl + "/q/oidc/";
     }
 
+    private static final String OIDC_TOKEN_PATH = "/protocol/openid-connect/token";
+
+    /**
+     * Extracts the realm URL from a token endpoint URL by stripping the OIDC token path suffix.
+     * If the URL does not end with the token path, it is returned unchanged.
+     *
+     * @param tokenEndpoint The token endpoint URL.
+     * @return The realm URL.
+     */
+    public static String toRealmUrl(String tokenEndpoint) {
+        if (tokenEndpoint != null && tokenEndpoint.endsWith(OIDC_TOKEN_PATH)) {
+            return tokenEndpoint.substring(0, tokenEndpoint.length() - OIDC_TOKEN_PATH.length());
+        }
+        return tokenEndpoint;
+    }
+
     /**
      * Automatically resolve the best URI to use
      * @param registrationUri

--- a/capabilities-security/src/test/java/ai/wanaku/capabilities/sdk/security/TokenEndpointTest.java
+++ b/capabilities-security/src/test/java/ai/wanaku/capabilities/sdk/security/TokenEndpointTest.java
@@ -2,6 +2,7 @@ package ai.wanaku.capabilities.sdk.security;
 
 import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 class TokenEndpointTest {
 
@@ -79,6 +80,29 @@ class TokenEndpointTest {
         String expected = "/protocol/openid-connect/token";
 
         assertEquals(expected, result);
+    }
+
+    @Test
+    void toRealmUrlStripsTokenPath() {
+        String tokenEndpoint = "https://auth.example.com/realms/wanaku/protocol/openid-connect/token";
+        assertEquals("https://auth.example.com/realms/wanaku", TokenEndpoint.toRealmUrl(tokenEndpoint));
+    }
+
+    @Test
+    void toRealmUrlPreservesRealmUrl() {
+        String realmUrl = "https://auth.example.com/realms/wanaku";
+        assertEquals(realmUrl, TokenEndpoint.toRealmUrl(realmUrl));
+    }
+
+    @Test
+    void toRealmUrlHandlesCustomRealm() {
+        String tokenEndpoint = "https://auth.example.com/realms/custom-realm/protocol/openid-connect/token";
+        assertEquals("https://auth.example.com/realms/custom-realm", TokenEndpoint.toRealmUrl(tokenEndpoint));
+    }
+
+    @Test
+    void toRealmUrlReturnsNullForNull() {
+        assertNull(TokenEndpoint.toRealmUrl(null));
     }
 
     @Test


### PR DESCRIPTION
## Summary

- `ServiceAuthenticator.resolveIssuer` was using `config.getTokenEndpoint()` as the OIDC discovery base URL, but by the time it's called the value contains the full token endpoint path (`.../protocol/openid-connect/token`), producing an invalid discovery URL (`.../protocol/openid-connect/token/.well-known/openid-configuration` → HTTP 405)
- Added `TokenEndpoint.toRealmUrl()` to strip the OIDC token path suffix and derive the realm URL
- `resolveIssuer` now uses `toRealmUrl()` before constructing the `Issuer` for OIDC metadata discovery

## Test plan

- [x] Added unit tests for `toRealmUrl` covering: full token endpoint URL, plain realm URL, custom realm, and null input
- [x] Existing `TokenEndpointTest` and full build pass

## Summary by Sourcery

Normalize the configured token endpoint to a realm URL before OIDC discovery and cover the new helper logic with unit tests.

New Features:
- Add TokenEndpoint.toRealmUrl helper to derive the realm URL from a token endpoint URL

Bug Fixes:
- Fix OIDC issuer resolution by stripping the token endpoint path before performing OpenID discovery to avoid invalid discovery URLs

Tests:
- Add unit tests for TokenEndpoint.toRealmUrl covering full token endpoint URLs, plain realm URLs, custom realms, and null inputs