### PR TITLE
Fix wanaku-ai/camel-integration-capability#82: add pending health check grace period

### DIFF
--- a/capabilities-api/src/main/java/ai/wanaku/capabilities/sdk/api/types/discovery/ActivityRecord.java
+++ b/capabilities-api/src/main/java/ai/wanaku/capabilities/sdk/api/types/discovery/ActivityRecord.java
@@ -1,5 +1,6 @@
 package ai.wanaku.capabilities.sdk.api.types.discovery;
 
+import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
@@ -66,12 +67,18 @@ public class ActivityRecord implements WanakuEntity<String> {
      * Checks whether the service is currently active.
      * <p>
      * A service is considered active if its health status is {@link HealthStatus#HEALTHY}
-     * or {@link HealthStatus#PENDING}.
+     * or {@link HealthStatus#PENDING} within 1 minute from the moment it was last seen.
      *
      * @return {@code true} if the service is active, {@code false} otherwise
      */
     public boolean isActive() {
-        return healthStatus == HealthStatus.HEALTHY || healthStatus == HealthStatus.PENDING;
+        if (healthStatus == HealthStatus.HEALTHY) {
+            return true;
+        }
+        if (healthStatus == HealthStatus.PENDING && lastSeen != null) {
+            return Duration.between(lastSeen, Instant.now()).toMinutes() < 1;
+        }
+        return false;
     }
 
     /**


### PR DESCRIPTION
## Summary

- Add a 1-minute grace period for capabilities in `PENDING` health state in `ActivityRecord.isActive()`
- Previously, `PENDING` was treated as active indefinitely; now it expires after 1 minute from `lastSeen`

## Test plan

- [ ] Verify `isActive()` returns `true` for `HEALTHY` regardless of `lastSeen`
- [ ] Verify `isActive()` returns `true` for `PENDING` within 1 minute of `lastSeen`
- [ ] Verify `isActive()` returns `false` for `PENDING` after 1 minute
- [ ] Verify `isActive()` returns `false` for `PENDING` with `null` `lastSeen`
- [ ] Verify `isActive()` returns `false` for `UNHEALTHY` and `DOWN`

## Summary by Sourcery

Bug Fixes:
- Prevent capabilities in PENDING health state from being treated as active indefinitely by expiring them 1 minute after lastSeen.