### PR TITLE
fix incorrect down state for CIC

### DIFF
--- a/capabilities-api/src/main/java/ai/wanaku/capabilities/sdk/api/exceptions/ServiceUnavailableException.java
+++ b/capabilities-api/src/main/java/ai/wanaku/capabilities/sdk/api/exceptions/ServiceUnavailableException.java
@@ -6,21 +6,36 @@ package ai.wanaku.capabilities.sdk.api.exceptions;
  * @see WanakuException
  */
 public class ServiceUnavailableException extends WanakuException {
+    /**
+     * Whether the conditions causing the service to be unavailable are temporary
+     */
+    private final boolean transientCondition;
 
     /**
      * Constructs an instance of the exception with no detail message or cause.
      */
     public ServiceUnavailableException() {
+        this(false);
+    }
+
+    /**
+     * Constructs an instance of the exception with no detail message or cause.
+     * @param transientCondition whether the conditions causing the service to be unavailable are temporary
+     */
+    public ServiceUnavailableException(boolean transientCondition) {
         super();
+        this.transientCondition = transientCondition;
     }
 
     /**
      * Constructs an instance of the exception with a specified detail message.
      *
-     * @param message the detail message for this exception
+     * @param message            the detail message for this exception
+     * @param transientCondition whether the conditions causing the service to be unavailable are temporary
      */
-    public ServiceUnavailableException(String message) {
+    public ServiceUnavailableException(String message, boolean transientCondition) {
         super(message);
+        this.transientCondition = transientCondition;
     }
 
     /**
@@ -30,16 +45,30 @@ public class ServiceUnavailableException extends WanakuException {
      * @param cause   the cause (which is saved for later retrieval by the {@link Throwable#getCause()} method)
      */
     public ServiceUnavailableException(String message, Throwable cause) {
+        this(message, cause, false);
+    }
+
+    /**
+     * Constructs an instance of the exception with a specified cause and a detail message.
+     *
+     * @param message the detail message for this exception
+     * @param cause   the cause (which is saved for later retrieval by the {@link Throwable#getCause()} method)
+     * @param transientCondition whether the conditions causing the service to be unavailable are temporary
+     */
+    public ServiceUnavailableException(String message, Throwable cause, boolean transientCondition) {
         super(message, cause);
+        this.transientCondition = transientCondition;
     }
 
     /**
      * Constructs an instance of the exception with a specified cause.
      *
      * @param cause the cause (which is saved for later retrieval by the {@link Throwable#getCause()} method)
+     * @param transientCondition whether the conditions causing the service to be unavailable are temporary
      */
-    public ServiceUnavailableException(Throwable cause) {
+    public ServiceUnavailableException(Throwable cause, boolean transientCondition) {
         super(cause);
+        this.transientCondition = transientCondition;
     }
 
     /**
@@ -50,10 +79,24 @@ public class ServiceUnavailableException extends WanakuException {
      * @param cause           the cause (which is saved for later retrieval by the {@link Throwable#getCause()} method)
      * @param enableSuppression whether suppression is enabled or disabled
      * @param writableStackTrace  whether the stack trace should be writable
+     * @param transientCondition whether the conditions causing the service to be unavailable are temporary
      */
     public ServiceUnavailableException(
-            String message, Throwable cause, boolean enableSuppression, boolean writableStackTrace) {
+            String message,
+            Throwable cause,
+            boolean enableSuppression,
+            boolean writableStackTrace,
+            boolean transientCondition) {
         super(message, cause, enableSuppression, writableStackTrace);
+        this.transientCondition = transientCondition;
+    }
+
+    /**
+     * Whether the unavailability was caused by a temporary condition
+     * @return true if temporary, false otherwise
+     */
+    public boolean isTransientCondition() {
+        return transientCondition;
     }
 
     /**
@@ -63,7 +106,7 @@ public class ServiceUnavailableException extends WanakuException {
      * @return a new instance of this exception for the specified service name
      */
     public static ServiceUnavailableException forName(String serviceName) {
-        return new ServiceUnavailableException(String.format("Service is not available at %s", serviceName));
+        return new ServiceUnavailableException(String.format("Service is not available at %s", serviceName), false);
     }
 
     /**
@@ -74,6 +117,7 @@ public class ServiceUnavailableException extends WanakuException {
      * @return a new instance of this exception for the specified service name
      */
     public static ServiceUnavailableException forAddress(String address) {
-        return new ServiceUnavailableException(String.format("Service is not available at the address %s", address));
+        return new ServiceUnavailableException(
+                String.format("Service is not available at the address %s", address), false);
     }
 }

--- a/capabilities-api/src/main/java/ai/wanaku/capabilities/sdk/api/types/discovery/ActivityRecord.java
+++ b/capabilities-api/src/main/java/ai/wanaku/capabilities/sdk/api/types/discovery/ActivityRecord.java
@@ -15,6 +15,12 @@ import ai.wanaku.capabilities.sdk.api.types.WanakuEntity;
  * are used by the service discovery mechanism to monitor service health and availability.
  */
 public class ActivityRecord implements WanakuEntity<String> {
+    /**
+     * The maximum amount of time, in minutes, the service can be in pending
+     * state until it can be considered fully gone/down.
+     */
+    public static final int TIME_TO_LET_GO = 10;
+
     private String id;
     private Instant lastSeen;
     private HealthStatus healthStatus = HealthStatus.PENDING;
@@ -67,7 +73,7 @@ public class ActivityRecord implements WanakuEntity<String> {
      * Checks whether the service is currently active.
      * <p>
      * A service is considered active if its health status is {@link HealthStatus#HEALTHY}
-     * or {@link HealthStatus#PENDING} within 1 minute from the moment it was last seen.
+     * or {@link HealthStatus#PENDING} within {@link ActivityRecord#TIME_TO_LET_GO} minutes from the moment it was last seen.
      *
      * @return {@code true} if the service is active, {@code false} otherwise
      */
@@ -76,7 +82,7 @@ public class ActivityRecord implements WanakuEntity<String> {
             return true;
         }
         if (healthStatus == HealthStatus.PENDING && lastSeen != null) {
-            return Duration.between(lastSeen, Instant.now()).toMinutes() < 1;
+            return Duration.between(lastSeen, Instant.now()).toMinutes() < TIME_TO_LET_GO;
         }
         return false;
     }

--- a/capabilities-runtimes/capabilities-runtimes-camel/capabilities-runtimes-camel-common/src/main/java/ai/wanaku/capabilities/sdk/runtime/camel/grpc/CamelContextResolver.java
+++ b/capabilities-runtimes/capabilities-runtimes-camel/capabilities-runtimes-camel-common/src/main/java/ai/wanaku/capabilities/sdk/runtime/camel/grpc/CamelContextResolver.java
@@ -1,0 +1,44 @@
+package ai.wanaku.capabilities.sdk.runtime.camel.grpc;
+
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import org.apache.camel.CamelContext;
+import io.grpc.Status;
+
+public class CamelContextResolver {
+    private final Future<CamelContext> camelContextFuture;
+    private volatile CamelContext camelContext;
+
+    public CamelContextResolver(Future<CamelContext> camelContextFuture) {
+        this.camelContextFuture = camelContextFuture;
+    }
+
+    public CamelContext resolve() {
+        CamelContext ctx = this.camelContext;
+        if (ctx != null) {
+            return ctx;
+        }
+
+        if (!camelContextFuture.isDone()) {
+            throw Status.FAILED_PRECONDITION
+                    .withDescription("Camel context is not yet available")
+                    .asRuntimeException();
+        }
+
+        try {
+            ctx = camelContextFuture.get();
+            this.camelContext = ctx;
+            return ctx;
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw Status.UNAVAILABLE
+                    .withDescription("Interrupted while obtaining Camel context")
+                    .asRuntimeException();
+        } catch (ExecutionException e) {
+            throw Status.UNAVAILABLE
+                    .withDescription("Failed to initialize Camel context: "
+                            + e.getCause().getMessage())
+                    .asRuntimeException();
+        }
+    }
+}

--- a/capabilities-runtimes/capabilities-runtimes-camel/capabilities-runtimes-camel-common/src/main/java/ai/wanaku/capabilities/sdk/runtime/camel/grpc/CamelHealthProbe.java
+++ b/capabilities-runtimes/capabilities-runtimes-camel/capabilities-runtimes-camel-common/src/main/java/ai/wanaku/capabilities/sdk/runtime/camel/grpc/CamelHealthProbe.java
@@ -1,13 +1,13 @@
 package ai.wanaku.capabilities.sdk.runtime.camel.grpc;
 
 import java.util.Objects;
+import java.util.concurrent.Future;
 import org.apache.camel.CamelContext;
 import org.apache.camel.ServiceStatus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import io.grpc.Status;
 import io.grpc.stub.StreamObserver;
-import ai.wanaku.capabilities.sdk.api.exceptions.WanakuException;
 import ai.wanaku.capabilities.sdk.api.types.providers.ServiceTarget;
 import ai.wanaku.core.exchange.v1.HealthProbeGrpc;
 import ai.wanaku.core.exchange.v1.HealthProbeReply;
@@ -17,16 +17,12 @@ import ai.wanaku.core.exchange.v1.RuntimeStatus;
 public class CamelHealthProbe extends HealthProbeGrpc.HealthProbeImplBase {
     private static final Logger LOG = LoggerFactory.getLogger(CamelHealthProbe.class);
 
-    private final CamelContext camelContext;
+    private final CamelContextResolver contextResolver;
     private final ServiceTarget target;
 
-    public CamelHealthProbe(CamelContext camelContext, ServiceTarget target) {
-        this.camelContext = camelContext;
+    public CamelHealthProbe(Future<CamelContext> camelContextFuture, ServiceTarget target) {
+        this.contextResolver = new CamelContextResolver(camelContextFuture);
         this.target = Objects.requireNonNull(target);
-
-        if (target.getId().isEmpty()) {
-            throw new WanakuException("Invalid capability service ID");
-        }
     }
 
     public RuntimeStatus getStatus(ServiceStatus serviceStatus) {
@@ -45,13 +41,28 @@ public class CamelHealthProbe extends HealthProbeGrpc.HealthProbeImplBase {
 
     @Override
     public void getStatus(HealthProbeRequest request, StreamObserver<HealthProbeReply> responseObserver) {
+        if (target.getId() == null || target.getId().isEmpty()) {
+            responseObserver.onError(Status.UNAVAILABLE
+                    .withDescription("Service is not yet registered")
+                    .asRuntimeException());
+            return;
+        }
+
         if (!target.getId().equals(request.getId())) {
             LOG.error("Requested capability ID ({}) doesn't match exiting one {}", request.getId(), target.getId());
             responseObserver.onError(Status.INVALID_ARGUMENT
                     .withDescription("Invalid request id " + request.getId())
                     .asRuntimeException());
         } else {
-            RuntimeStatus status = getStatus(camelContext.getStatus());
+            final CamelContext ctx;
+            try {
+                ctx = contextResolver.resolve();
+            } catch (Exception e) {
+                responseObserver.onError(e);
+                return;
+            }
+
+            RuntimeStatus status = getStatus(ctx.getStatus());
             responseObserver.onNext(
                     HealthProbeReply.newBuilder().setStatus(status).build());
             responseObserver.onCompleted();

--- a/capabilities-runtimes/capabilities-runtimes-camel/capabilities-runtimes-camel-common/src/main/java/ai/wanaku/capabilities/sdk/runtime/camel/grpc/CamelResource.java
+++ b/capabilities-runtimes/capabilities-runtimes-camel/capabilities-runtimes-camel-common/src/main/java/ai/wanaku/capabilities/sdk/runtime/camel/grpc/CamelResource.java
@@ -4,6 +4,7 @@ import java.net.URI;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.Future;
 import org.apache.camel.CamelContext;
 import org.apache.camel.ConsumerTemplate;
 import org.apache.camel.Route;
@@ -20,11 +21,11 @@ import ai.wanaku.core.exchange.v1.ResourceRequest;
 public class CamelResource extends ResourceAcquirerGrpc.ResourceAcquirerImplBase {
     private static final Logger LOG = LoggerFactory.getLogger(CamelResource.class);
 
+    private final CamelContextResolver contextResolver;
     private final McpSpec mcpSpec;
-    private final CamelContext camelContext;
 
-    public CamelResource(CamelContext camelContext, McpSpec mcpSpec) {
-        this.camelContext = camelContext;
+    public CamelResource(Future<CamelContext> camelContextFuture, McpSpec mcpSpec) {
+        this.contextResolver = new CamelContextResolver(camelContextFuture);
         this.mcpSpec = mcpSpec;
     }
 
@@ -38,6 +39,14 @@ public class CamelResource extends ResourceAcquirerGrpc.ResourceAcquirerImplBase
     @Override
     public void resourceAcquire(ResourceRequest request, StreamObserver<ResourceReply> responseObserver) {
         LOG.debug("About to run a Camel route as resource provider");
+
+        final CamelContext ctx;
+        try {
+            ctx = contextResolver.resolve();
+        } catch (Exception e) {
+            responseObserver.onError(e);
+            return;
+        }
 
         final String uri = request.getLocation();
         URI routeUri = URI.create(uri);
@@ -54,8 +63,8 @@ public class CamelResource extends ResourceAcquirerGrpc.ResourceAcquirerImplBase
             return;
         }
 
-        try (final ConsumerTemplate consumerTemplate = camelContext.createConsumerTemplate()) {
-            final String endpointUri = resolveEndpoint(definition, camelContext);
+        try (final ConsumerTemplate consumerTemplate = ctx.createConsumerTemplate()) {
+            final String endpointUri = resolveEndpoint(definition, ctx);
             LOG.info("Consuming from {} as {}", endpointUri, routeUri);
 
             Object ret = consumerTemplate.receiveBody(endpointUri, 5000, String.class);

--- a/capabilities-runtimes/capabilities-runtimes-camel/capabilities-runtimes-camel-common/src/main/java/ai/wanaku/capabilities/sdk/runtime/camel/grpc/CamelTool.java
+++ b/capabilities-runtimes/capabilities-runtimes-camel/capabilities-runtimes-camel-common/src/main/java/ai/wanaku/capabilities/sdk/runtime/camel/grpc/CamelTool.java
@@ -4,6 +4,7 @@ import java.net.URI;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.Future;
 import org.apache.camel.CamelContext;
 import org.apache.camel.ProducerTemplate;
 import org.apache.camel.Route;
@@ -22,11 +23,11 @@ import ai.wanaku.core.exchange.v1.ToolInvokerGrpc;
 public class CamelTool extends ToolInvokerGrpc.ToolInvokerImplBase {
     private static final Logger LOG = LoggerFactory.getLogger(CamelTool.class);
 
+    private final CamelContextResolver contextResolver;
     private final McpSpec mcpSpec;
-    private final CamelContext camelContext;
 
-    public CamelTool(CamelContext camelContext, McpSpec spec) {
-        this.camelContext = camelContext;
+    public CamelTool(Future<CamelContext> camelContextFuture, McpSpec spec) {
+        this.contextResolver = new CamelContextResolver(camelContextFuture);
         this.mcpSpec = spec;
     }
 
@@ -41,11 +42,18 @@ public class CamelTool extends ToolInvokerGrpc.ToolInvokerImplBase {
     public void invokeTool(ToolInvokeRequest request, StreamObserver<ToolInvokeReply> responseObserver) {
         LOG.debug("About to run a Camel route as tool");
 
+        final CamelContext ctx;
+        try {
+            ctx = contextResolver.resolve();
+        } catch (Exception e) {
+            responseObserver.onError(e);
+            return;
+        }
+
         final String uri = request.getUri();
         final URI routeUri = URI.create(uri);
         final String host = routeUri.getHost();
 
-        // Try to find the definition in tools first, then in resources
         Map<String, Definition> tools = getTools(mcpSpec);
         Definition toolDefinition = tools.get(host);
 
@@ -57,9 +65,9 @@ public class CamelTool extends ToolInvokerGrpc.ToolInvokerImplBase {
             return;
         }
 
-        final String endpointUri = resolveEndpoint(toolDefinition, camelContext);
+        final String endpointUri = resolveEndpoint(toolDefinition, ctx);
 
-        try (ProducerTemplate producerTemplate = camelContext.createProducerTemplate()) {
+        try (ProducerTemplate producerTemplate = ctx.createProducerTemplate()) {
             final Object reply;
 
             if (!request.getArgumentsMap().isEmpty()) {

--- a/capabilities-runtimes/capabilities-runtimes-camel/capabilities-runtimes-camel-plugin/src/main/java/ai/wanaku/capabilities/sdk/runtime/camel/plugin/CamelIntegrationPlugin.java
+++ b/capabilities-runtimes/capabilities-runtimes-camel/capabilities-runtimes-camel-plugin/src/main/java/ai/wanaku/capabilities/sdk/runtime/camel/plugin/CamelIntegrationPlugin.java
@@ -6,6 +6,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
 import org.apache.camel.CamelContext;
 import org.apache.camel.spi.ContextServicePlugin;
 import org.slf4j.Logger;
@@ -118,14 +119,16 @@ public class CamelIntegrationPlugin implements ContextServicePlugin {
 
             McpSpec mcpSpec = createMcpSpec(httpClient, downloadedResources);
 
-            // Start gRPC server
+            CompletableFuture<CamelContext> contextFuture = new CompletableFuture<>();
+            contextFuture.complete(camelContext);
+
             final ServerBuilder<?> serverBuilder =
                     Grpc.newServerBuilderForPort(config.getGrpcPort(), InsecureServerCredentials.create());
             grpcServer = serverBuilder
-                    .addService(new CamelTool(camelContext, mcpSpec))
-                    .addService(new CamelResource(camelContext, mcpSpec))
+                    .addService(new CamelTool(contextFuture, mcpSpec))
+                    .addService(new CamelResource(contextFuture, mcpSpec))
                     .addService(new ProvisionBase(config.getServiceName()))
-                    .addService(new CamelHealthProbe(camelContext, registrationManager.getTarget()))
+                    .addService(new CamelHealthProbe(contextFuture, registrationManager.getTarget()))
                     .build();
 
             grpcServer.start();


### PR DESCRIPTION
- **Cleanup the time to let go check**
- **Refactor Camel-based service initialization to better support pre-registration**

## Summary by Sourcery

Introduce support for deferred Camel context initialization and improve handling of transient service unavailability and activity tracking.

Bug Fixes:
- Increase the allowed pending time window before a service is considered down to avoid premature marking of capabilities as unavailable.
- Return appropriate gRPC errors when the capability service is not yet registered or when the Camel context is not yet initialized instead of failing generically.

Enhancements:
- Augment ServiceUnavailableException with a transient condition flag to distinguish temporary from permanent unavailability causes.
- Refactor Camel gRPC services (tool, resource, health probe) to obtain CamelContext via a shared future-based resolver, enabling safer pre-registration and reuse.
- Integrate the new CamelContextResolver into the Camel integration plugin via a future-based context wiring for the gRPC server.