### PR TITLE
Fix #82: introduce WanakuRegistrationInfo for thread-safe gRPC initialization

### DIFF
--- a/capabilities-runtimes/capabilities-runtimes-camel/capabilities-runtimes-camel-common/src/main/java/ai/wanaku/capabilities/sdk/runtime/camel/grpc/CamelContextResolver.java
+++ b/capabilities-runtimes/capabilities-runtimes-camel/capabilities-runtimes-camel-common/src/main/java/ai/wanaku/capabilities/sdk/runtime/camel/grpc/CamelContextResolver.java
@@ -2,33 +2,32 @@ package ai.wanaku.capabilities.sdk.runtime.camel.grpc;
 
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
-import org.apache.camel.CamelContext;
 import io.grpc.Status;
 
 public class CamelContextResolver {
-    private final Future<CamelContext> camelContextFuture;
-    private volatile CamelContext camelContext;
+    private final Future<WanakuRegistrationInfo> registrationInfoFuture;
+    private volatile WanakuRegistrationInfo registrationInfo;
 
-    public CamelContextResolver(Future<CamelContext> camelContextFuture) {
-        this.camelContextFuture = camelContextFuture;
+    public CamelContextResolver(Future<WanakuRegistrationInfo> registrationInfoFuture) {
+        this.registrationInfoFuture = registrationInfoFuture;
     }
 
-    public CamelContext resolve() {
-        CamelContext ctx = this.camelContext;
-        if (ctx != null) {
-            return ctx;
+    public WanakuRegistrationInfo resolve() {
+        WanakuRegistrationInfo info = this.registrationInfo;
+        if (info != null) {
+            return info;
         }
 
-        if (!camelContextFuture.isDone()) {
+        if (!registrationInfoFuture.isDone()) {
             throw Status.FAILED_PRECONDITION
                     .withDescription("Camel context is not yet available")
                     .asRuntimeException();
         }
 
         try {
-            ctx = camelContextFuture.get();
-            this.camelContext = ctx;
-            return ctx;
+            info = registrationInfoFuture.get();
+            this.registrationInfo = info;
+            return info;
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
             throw Status.UNAVAILABLE

--- a/capabilities-runtimes/capabilities-runtimes-camel/capabilities-runtimes-camel-common/src/main/java/ai/wanaku/capabilities/sdk/runtime/camel/grpc/CamelHealthProbe.java
+++ b/capabilities-runtimes/capabilities-runtimes-camel/capabilities-runtimes-camel-common/src/main/java/ai/wanaku/capabilities/sdk/runtime/camel/grpc/CamelHealthProbe.java
@@ -1,13 +1,11 @@
 package ai.wanaku.capabilities.sdk.runtime.camel.grpc;
 
-import java.util.Objects;
 import java.util.concurrent.Future;
 import org.apache.camel.ServiceStatus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import io.grpc.Status;
 import io.grpc.stub.StreamObserver;
-import ai.wanaku.capabilities.sdk.api.types.providers.ServiceTarget;
 import ai.wanaku.core.exchange.v1.HealthProbeGrpc;
 import ai.wanaku.core.exchange.v1.HealthProbeReply;
 import ai.wanaku.core.exchange.v1.HealthProbeRequest;
@@ -16,12 +14,10 @@ import ai.wanaku.core.exchange.v1.RuntimeStatus;
 public class CamelHealthProbe extends HealthProbeGrpc.HealthProbeImplBase {
     private static final Logger LOG = LoggerFactory.getLogger(CamelHealthProbe.class);
 
-    private final CamelContextResolver contextResolver;
-    private final ServiceTarget target;
+    private final WanakuRegistrationInfoResolver registrationInfoResolver;
 
-    public CamelHealthProbe(Future<WanakuRegistrationInfo> registrationInfoFuture, ServiceTarget target) {
-        this.contextResolver = new CamelContextResolver(registrationInfoFuture);
-        this.target = Objects.requireNonNull(target);
+    public CamelHealthProbe(Future<WanakuRegistrationInfo> registrationInfoFuture) {
+        this.registrationInfoResolver = new WanakuRegistrationInfoResolver(registrationInfoFuture);
     }
 
     public RuntimeStatus getStatus(ServiceStatus serviceStatus) {
@@ -40,27 +36,23 @@ public class CamelHealthProbe extends HealthProbeGrpc.HealthProbeImplBase {
 
     @Override
     public void getStatus(HealthProbeRequest request, StreamObserver<HealthProbeReply> responseObserver) {
-        if (target.getId() == null || target.getId().isEmpty()) {
-            responseObserver.onError(Status.UNAVAILABLE
-                    .withDescription("Service is not yet registered")
-                    .asRuntimeException());
+        final WanakuRegistrationInfo info;
+        try {
+            info = registrationInfoResolver.resolve();
+        } catch (Exception e) {
+            responseObserver.onError(e);
             return;
         }
 
-        if (!target.getId().equals(request.getId())) {
-            LOG.error("Requested capability ID ({}) doesn't match exiting one {}", request.getId(), target.getId());
+        if (!info.serviceTarget().getId().equals(request.getId())) {
+            LOG.error(
+                    "Requested capability ID ({}) doesn't match existing one {}",
+                    request.getId(),
+                    info.serviceTarget().getId());
             responseObserver.onError(Status.INVALID_ARGUMENT
                     .withDescription("Invalid request id " + request.getId())
                     .asRuntimeException());
         } else {
-            final WanakuRegistrationInfo info;
-            try {
-                info = contextResolver.resolve();
-            } catch (Exception e) {
-                responseObserver.onError(e);
-                return;
-            }
-
             RuntimeStatus status = getStatus(info.camelContext().getStatus());
             responseObserver.onNext(
                     HealthProbeReply.newBuilder().setStatus(status).build());

--- a/capabilities-runtimes/capabilities-runtimes-camel/capabilities-runtimes-camel-common/src/main/java/ai/wanaku/capabilities/sdk/runtime/camel/grpc/CamelHealthProbe.java
+++ b/capabilities-runtimes/capabilities-runtimes-camel/capabilities-runtimes-camel-common/src/main/java/ai/wanaku/capabilities/sdk/runtime/camel/grpc/CamelHealthProbe.java
@@ -2,7 +2,6 @@ package ai.wanaku.capabilities.sdk.runtime.camel.grpc;
 
 import java.util.Objects;
 import java.util.concurrent.Future;
-import org.apache.camel.CamelContext;
 import org.apache.camel.ServiceStatus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -20,8 +19,8 @@ public class CamelHealthProbe extends HealthProbeGrpc.HealthProbeImplBase {
     private final CamelContextResolver contextResolver;
     private final ServiceTarget target;
 
-    public CamelHealthProbe(Future<CamelContext> camelContextFuture, ServiceTarget target) {
-        this.contextResolver = new CamelContextResolver(camelContextFuture);
+    public CamelHealthProbe(Future<WanakuRegistrationInfo> registrationInfoFuture, ServiceTarget target) {
+        this.contextResolver = new CamelContextResolver(registrationInfoFuture);
         this.target = Objects.requireNonNull(target);
     }
 
@@ -54,15 +53,15 @@ public class CamelHealthProbe extends HealthProbeGrpc.HealthProbeImplBase {
                     .withDescription("Invalid request id " + request.getId())
                     .asRuntimeException());
         } else {
-            final CamelContext ctx;
+            final WanakuRegistrationInfo info;
             try {
-                ctx = contextResolver.resolve();
+                info = contextResolver.resolve();
             } catch (Exception e) {
                 responseObserver.onError(e);
                 return;
             }
 
-            RuntimeStatus status = getStatus(ctx.getStatus());
+            RuntimeStatus status = getStatus(info.camelContext().getStatus());
             responseObserver.onNext(
                     HealthProbeReply.newBuilder().setStatus(status).build());
             responseObserver.onCompleted();

--- a/capabilities-runtimes/capabilities-runtimes-camel/capabilities-runtimes-camel-common/src/main/java/ai/wanaku/capabilities/sdk/runtime/camel/grpc/CamelResource.java
+++ b/capabilities-runtimes/capabilities-runtimes-camel/capabilities-runtimes-camel-common/src/main/java/ai/wanaku/capabilities/sdk/runtime/camel/grpc/CamelResource.java
@@ -21,10 +21,10 @@ import ai.wanaku.core.exchange.v1.ResourceRequest;
 public class CamelResource extends ResourceAcquirerGrpc.ResourceAcquirerImplBase {
     private static final Logger LOG = LoggerFactory.getLogger(CamelResource.class);
 
-    private final CamelContextResolver contextResolver;
+    private final WanakuRegistrationInfoResolver contextResolver;
 
     public CamelResource(Future<WanakuRegistrationInfo> registrationInfoFuture) {
-        this.contextResolver = new CamelContextResolver(registrationInfoFuture);
+        this.contextResolver = new WanakuRegistrationInfoResolver(registrationInfoFuture);
     }
 
     public Map<String, Definition> getResources(McpSpec mcpSpec) {

--- a/capabilities-runtimes/capabilities-runtimes-camel/capabilities-runtimes-camel-common/src/main/java/ai/wanaku/capabilities/sdk/runtime/camel/grpc/CamelResource.java
+++ b/capabilities-runtimes/capabilities-runtimes-camel/capabilities-runtimes-camel-common/src/main/java/ai/wanaku/capabilities/sdk/runtime/camel/grpc/CamelResource.java
@@ -22,11 +22,9 @@ public class CamelResource extends ResourceAcquirerGrpc.ResourceAcquirerImplBase
     private static final Logger LOG = LoggerFactory.getLogger(CamelResource.class);
 
     private final CamelContextResolver contextResolver;
-    private final McpSpec mcpSpec;
 
-    public CamelResource(Future<CamelContext> camelContextFuture, McpSpec mcpSpec) {
-        this.contextResolver = new CamelContextResolver(camelContextFuture);
-        this.mcpSpec = mcpSpec;
+    public CamelResource(Future<WanakuRegistrationInfo> registrationInfoFuture) {
+        this.contextResolver = new CamelContextResolver(registrationInfoFuture);
     }
 
     public Map<String, Definition> getResources(McpSpec mcpSpec) {
@@ -40,19 +38,20 @@ public class CamelResource extends ResourceAcquirerGrpc.ResourceAcquirerImplBase
     public void resourceAcquire(ResourceRequest request, StreamObserver<ResourceReply> responseObserver) {
         LOG.debug("About to run a Camel route as resource provider");
 
-        final CamelContext ctx;
+        final WanakuRegistrationInfo info;
         try {
-            ctx = contextResolver.resolve();
+            info = contextResolver.resolve();
         } catch (Exception e) {
             responseObserver.onError(e);
             return;
         }
 
+        final CamelContext ctx = info.camelContext();
         final String uri = request.getLocation();
         URI routeUri = URI.create(uri);
         final String host = routeUri.getHost();
 
-        Map<String, Definition> resources = getResources(mcpSpec);
+        Map<String, Definition> resources = getResources(info.mcpSpec());
         Definition definition = resources.get(host);
 
         if (definition == null) {

--- a/capabilities-runtimes/capabilities-runtimes-camel/capabilities-runtimes-camel-common/src/main/java/ai/wanaku/capabilities/sdk/runtime/camel/grpc/CamelTool.java
+++ b/capabilities-runtimes/capabilities-runtimes-camel/capabilities-runtimes-camel-common/src/main/java/ai/wanaku/capabilities/sdk/runtime/camel/grpc/CamelTool.java
@@ -24,11 +24,9 @@ public class CamelTool extends ToolInvokerGrpc.ToolInvokerImplBase {
     private static final Logger LOG = LoggerFactory.getLogger(CamelTool.class);
 
     private final CamelContextResolver contextResolver;
-    private final McpSpec mcpSpec;
 
-    public CamelTool(Future<CamelContext> camelContextFuture, McpSpec spec) {
-        this.contextResolver = new CamelContextResolver(camelContextFuture);
-        this.mcpSpec = spec;
+    public CamelTool(Future<WanakuRegistrationInfo> registrationInfoFuture) {
+        this.contextResolver = new CamelContextResolver(registrationInfoFuture);
     }
 
     public Map<String, Definition> getTools(McpSpec mcpSpec) {
@@ -42,19 +40,20 @@ public class CamelTool extends ToolInvokerGrpc.ToolInvokerImplBase {
     public void invokeTool(ToolInvokeRequest request, StreamObserver<ToolInvokeReply> responseObserver) {
         LOG.debug("About to run a Camel route as tool");
 
-        final CamelContext ctx;
+        final WanakuRegistrationInfo info;
         try {
-            ctx = contextResolver.resolve();
+            info = contextResolver.resolve();
         } catch (Exception e) {
             responseObserver.onError(e);
             return;
         }
 
+        final CamelContext ctx = info.camelContext();
         final String uri = request.getUri();
         final URI routeUri = URI.create(uri);
         final String host = routeUri.getHost();
 
-        Map<String, Definition> tools = getTools(mcpSpec);
+        Map<String, Definition> tools = getTools(info.mcpSpec());
         Definition toolDefinition = tools.get(host);
 
         if (toolDefinition == null) {

--- a/capabilities-runtimes/capabilities-runtimes-camel/capabilities-runtimes-camel-common/src/main/java/ai/wanaku/capabilities/sdk/runtime/camel/grpc/CamelTool.java
+++ b/capabilities-runtimes/capabilities-runtimes-camel/capabilities-runtimes-camel-common/src/main/java/ai/wanaku/capabilities/sdk/runtime/camel/grpc/CamelTool.java
@@ -23,10 +23,10 @@ import ai.wanaku.core.exchange.v1.ToolInvokerGrpc;
 public class CamelTool extends ToolInvokerGrpc.ToolInvokerImplBase {
     private static final Logger LOG = LoggerFactory.getLogger(CamelTool.class);
 
-    private final CamelContextResolver contextResolver;
+    private final WanakuRegistrationInfoResolver contextResolver;
 
     public CamelTool(Future<WanakuRegistrationInfo> registrationInfoFuture) {
-        this.contextResolver = new CamelContextResolver(registrationInfoFuture);
+        this.contextResolver = new WanakuRegistrationInfoResolver(registrationInfoFuture);
     }
 
     public Map<String, Definition> getTools(McpSpec mcpSpec) {

--- a/capabilities-runtimes/capabilities-runtimes-camel/capabilities-runtimes-camel-common/src/main/java/ai/wanaku/capabilities/sdk/runtime/camel/grpc/WanakuRegistrationInfo.java
+++ b/capabilities-runtimes/capabilities-runtimes-camel/capabilities-runtimes-camel-common/src/main/java/ai/wanaku/capabilities/sdk/runtime/camel/grpc/WanakuRegistrationInfo.java
@@ -1,0 +1,6 @@
+package ai.wanaku.capabilities.sdk.runtime.camel.grpc;
+
+import org.apache.camel.CamelContext;
+import ai.wanaku.capabilities.sdk.runtime.camel.model.McpSpec;
+
+public record WanakuRegistrationInfo(CamelContext camelContext, McpSpec mcpSpec) {}

--- a/capabilities-runtimes/capabilities-runtimes-camel/capabilities-runtimes-camel-common/src/main/java/ai/wanaku/capabilities/sdk/runtime/camel/grpc/WanakuRegistrationInfo.java
+++ b/capabilities-runtimes/capabilities-runtimes-camel/capabilities-runtimes-camel-common/src/main/java/ai/wanaku/capabilities/sdk/runtime/camel/grpc/WanakuRegistrationInfo.java
@@ -1,6 +1,7 @@
 package ai.wanaku.capabilities.sdk.runtime.camel.grpc;
 
 import org.apache.camel.CamelContext;
+import ai.wanaku.capabilities.sdk.api.types.providers.ServiceTarget;
 import ai.wanaku.capabilities.sdk.runtime.camel.model.McpSpec;
 
-public record WanakuRegistrationInfo(CamelContext camelContext, McpSpec mcpSpec) {}
+public record WanakuRegistrationInfo(CamelContext camelContext, McpSpec mcpSpec, ServiceTarget serviceTarget) {}

--- a/capabilities-runtimes/capabilities-runtimes-camel/capabilities-runtimes-camel-common/src/main/java/ai/wanaku/capabilities/sdk/runtime/camel/grpc/WanakuRegistrationInfoResolver.java
+++ b/capabilities-runtimes/capabilities-runtimes-camel/capabilities-runtimes-camel-common/src/main/java/ai/wanaku/capabilities/sdk/runtime/camel/grpc/WanakuRegistrationInfoResolver.java
@@ -4,11 +4,11 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import io.grpc.Status;
 
-public class CamelContextResolver {
+public class WanakuRegistrationInfoResolver {
     private final Future<WanakuRegistrationInfo> registrationInfoFuture;
     private volatile WanakuRegistrationInfo registrationInfo;
 
-    public CamelContextResolver(Future<WanakuRegistrationInfo> registrationInfoFuture) {
+    public WanakuRegistrationInfoResolver(Future<WanakuRegistrationInfo> registrationInfoFuture) {
         this.registrationInfoFuture = registrationInfoFuture;
     }
 

--- a/capabilities-runtimes/capabilities-runtimes-camel/capabilities-runtimes-camel-plugin/src/main/java/ai/wanaku/capabilities/sdk/runtime/camel/plugin/CamelIntegrationPlugin.java
+++ b/capabilities-runtimes/capabilities-runtimes-camel/capabilities-runtimes-camel-plugin/src/main/java/ai/wanaku/capabilities/sdk/runtime/camel/plugin/CamelIntegrationPlugin.java
@@ -38,6 +38,7 @@ import ai.wanaku.capabilities.sdk.runtime.camel.grpc.CamelHealthProbe;
 import ai.wanaku.capabilities.sdk.runtime.camel.grpc.CamelResource;
 import ai.wanaku.capabilities.sdk.runtime.camel.grpc.CamelTool;
 import ai.wanaku.capabilities.sdk.runtime.camel.grpc.ProvisionBase;
+import ai.wanaku.capabilities.sdk.runtime.camel.grpc.WanakuRegistrationInfo;
 import ai.wanaku.capabilities.sdk.runtime.camel.init.Initializer;
 import ai.wanaku.capabilities.sdk.runtime.camel.init.InitializerFactory;
 import ai.wanaku.capabilities.sdk.runtime.camel.model.McpSpec;
@@ -119,16 +120,16 @@ public class CamelIntegrationPlugin implements ContextServicePlugin {
 
             McpSpec mcpSpec = createMcpSpec(httpClient, downloadedResources);
 
-            CompletableFuture<CamelContext> contextFuture = new CompletableFuture<>();
-            contextFuture.complete(camelContext);
+            CompletableFuture<WanakuRegistrationInfo> registrationInfoFuture = new CompletableFuture<>();
+            registrationInfoFuture.complete(new WanakuRegistrationInfo(camelContext, mcpSpec));
 
             final ServerBuilder<?> serverBuilder =
                     Grpc.newServerBuilderForPort(config.getGrpcPort(), InsecureServerCredentials.create());
             grpcServer = serverBuilder
-                    .addService(new CamelTool(contextFuture, mcpSpec))
-                    .addService(new CamelResource(contextFuture, mcpSpec))
+                    .addService(new CamelTool(registrationInfoFuture))
+                    .addService(new CamelResource(registrationInfoFuture))
                     .addService(new ProvisionBase(config.getServiceName()))
-                    .addService(new CamelHealthProbe(contextFuture, registrationManager.getTarget()))
+                    .addService(new CamelHealthProbe(registrationInfoFuture, registrationManager.getTarget()))
                     .build();
 
             grpcServer.start();

--- a/capabilities-runtimes/capabilities-runtimes-camel/capabilities-runtimes-camel-plugin/src/main/java/ai/wanaku/capabilities/sdk/runtime/camel/plugin/CamelIntegrationPlugin.java
+++ b/capabilities-runtimes/capabilities-runtimes-camel/capabilities-runtimes-camel-plugin/src/main/java/ai/wanaku/capabilities/sdk/runtime/camel/plugin/CamelIntegrationPlugin.java
@@ -121,7 +121,8 @@ public class CamelIntegrationPlugin implements ContextServicePlugin {
             McpSpec mcpSpec = createMcpSpec(httpClient, downloadedResources);
 
             CompletableFuture<WanakuRegistrationInfo> registrationInfoFuture = new CompletableFuture<>();
-            registrationInfoFuture.complete(new WanakuRegistrationInfo(camelContext, mcpSpec));
+            registrationInfoFuture.complete(
+                    new WanakuRegistrationInfo(camelContext, mcpSpec, registrationManager.getTarget()));
 
             final ServerBuilder<?> serverBuilder =
                     Grpc.newServerBuilderForPort(config.getGrpcPort(), InsecureServerCredentials.create());
@@ -129,7 +130,7 @@ public class CamelIntegrationPlugin implements ContextServicePlugin {
                     .addService(new CamelTool(registrationInfoFuture))
                     .addService(new CamelResource(registrationInfoFuture))
                     .addService(new ProvisionBase(config.getServiceName()))
-                    .addService(new CamelHealthProbe(registrationInfoFuture, registrationManager.getTarget()))
+                    .addService(new CamelHealthProbe(registrationInfoFuture))
                     .build();
 
             grpcServer.start();


### PR DESCRIPTION
## Summary

- Introduce `WanakuRegistrationInfo` immutable record holding `CamelContext`, `McpSpec`, and `ServiceTarget`
- gRPC services (`CamelTool`, `CamelResource`, `CamelHealthProbe`) now receive `Future<WanakuRegistrationInfo>` instead of separate `Future<CamelContext>` + mutable `McpSpec` + mutable `ServiceTarget`
- Rename `CamelContextResolver` to `WanakuRegistrationInfoResolver`
- Eliminates all mutable shared state between the gRPC server thread and the registration thread

## Test plan

- [x] SDK builds successfully
- [x] CamelIntegrationPlugin updated to use new API
- [ ] Downstream camel-integration-capability updated and tested (companion PR)

## Summary by Sourcery

Consolidate gRPC runtime initialization around an immutable WanakuRegistrationInfo record to provide thread-safe access to Camel context, MCP spec, and service target across services.

New Features:
- Introduce WanakuRegistrationInfo immutable record encapsulating CamelContext, McpSpec, and ServiceTarget for gRPC services.

Enhancements:
- Refactor CamelTool, CamelResource, and CamelHealthProbe to depend on Future<WanakuRegistrationInfo> instead of separate context, spec, and target inputs.
- Replace CamelContextResolver with WanakuRegistrationInfoResolver to resolve and cache complete registration information from a single future.
- Update CamelIntegrationPlugin to construct and supply WanakuRegistrationInfo to all gRPC services during server startup, eliminating shared mutable state between threads.