### PR TITLE
Upgrade Apache Camel to 4.18.2

### DIFF
--- a/capabilities-parent/pom.xml
+++ b/capabilities-parent/pom.xml
@@ -20,7 +20,7 @@
         <protobuf-maven-plugin.version>0.6.1</protobuf-maven-plugin.version>
         <spotless-maven-plugin.version>3.4.0</spotless-maven-plugin.version>
 
-        <camel.version>4.18.1</camel.version>
+        <camel.version>4.18.2</camel.version>
         <jgit.version>7.6.0.202603022253-r</jgit.version>
         <jackson-dataformat-yaml.version>2.21.2</jackson-dataformat-yaml.version>
         <jackson-databind.version>2.21.3</jackson-databind.version>


### PR DESCRIPTION
## Summary
- Bump Apache Camel version from 4.18.1 to 4.18.2

## Test plan
- [x] Full `mvn verify` passes