### PR TITLE
ci issue add forage support

### DIFF
--- a/capabilities-bom/pom.xml
+++ b/capabilities-bom/pom.xml
@@ -81,6 +81,11 @@
                 <artifactId>langchain4j-code-execution-engine-wanaku</artifactId>
                 <version>${project.version}</version>
             </dependency>
+            <dependency>
+                <groupId>ai.wanaku.sdk</groupId>
+                <artifactId>capabilities-maven-downloader</artifactId>
+                <version>${project.version}</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/capabilities-maven-downloader/pom.xml
+++ b/capabilities-maven-downloader/pom.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>ai.wanaku.sdk</groupId>
+        <artifactId>capabilities-parent</artifactId>
+        <version>0.1.1-SNAPSHOT</version>
+        <relativePath>../capabilities-parent/pom.xml</relativePath>
+    </parent>
+
+    <artifactId>capabilities-maven-downloader</artifactId>
+    <name>Wanaku Capabilities SDK :: Maven Downloader</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>ai.wanaku.sdk</groupId>
+            <artifactId>capabilities-api</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.maven.resolver</groupId>
+            <artifactId>maven-resolver-api</artifactId>
+            <version>${maven.resolver.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven.resolver</groupId>
+            <artifactId>maven-resolver-util</artifactId>
+            <version>${maven.resolver.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven.resolver</groupId>
+            <artifactId>maven-resolver-supplier-mvn3</artifactId>
+            <version>${maven.resolver.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-resolver-provider</artifactId>
+            <version>${maven.resolver-provider.version}</version>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/capabilities-maven-downloader/src/main/java/ai/wanaku/capabilities/sdk/maven/DependencyDownloadException.java
+++ b/capabilities-maven-downloader/src/main/java/ai/wanaku/capabilities/sdk/maven/DependencyDownloadException.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.wanaku.capabilities.sdk.maven;
+
+import ai.wanaku.capabilities.sdk.api.exceptions.WanakuException;
+
+/**
+ * Thrown when one or more Maven dependencies cannot be resolved or downloaded.
+ */
+public class DependencyDownloadException extends WanakuException {
+
+    public DependencyDownloadException(String message) {
+        super(message);
+    }
+
+    public DependencyDownloadException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/capabilities-maven-downloader/src/main/java/ai/wanaku/capabilities/sdk/maven/GAV.java
+++ b/capabilities-maven-downloader/src/main/java/ai/wanaku/capabilities/sdk/maven/GAV.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.wanaku.capabilities.sdk.maven;
+
+import java.util.Objects;
+
+/**
+ * An immutable Maven coordinate consisting of group ID, artifact ID, and version.
+ *
+ * @param groupId    the Maven group ID
+ * @param artifactId the Maven artifact ID
+ * @param version    the Maven version
+ */
+public record GAV(String groupId, String artifactId, String version) {
+
+    public GAV {
+        Objects.requireNonNull(groupId, "groupId must not be null");
+        Objects.requireNonNull(artifactId, "artifactId must not be null");
+        Objects.requireNonNull(version, "version must not be null");
+    }
+
+    /**
+     * Parses a colon-separated GAV string (e.g. {@code "org.example:my-lib:1.0"}).
+     *
+     * @param gavString the GAV string to parse
+     * @return the parsed GAV
+     * @throws IllegalArgumentException if the string does not contain exactly three colon-separated parts
+     */
+    public static GAV parse(String gavString) {
+        Objects.requireNonNull(gavString, "GAV string must not be null");
+        String[] parts = gavString.split(":");
+        if (parts.length != 3) {
+            throw new IllegalArgumentException(
+                    "Invalid GAV format: expected 'groupId:artifactId:version' but got '" + gavString + "'");
+        }
+        return new GAV(parts[0].trim(), parts[1].trim(), parts[2].trim());
+    }
+
+    @Override
+    public String toString() {
+        return groupId + ":" + artifactId + ":" + version;
+    }
+}

--- a/capabilities-maven-downloader/src/main/java/ai/wanaku/capabilities/sdk/maven/Repository.java
+++ b/capabilities-maven-downloader/src/main/java/ai/wanaku/capabilities/sdk/maven/Repository.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.wanaku.capabilities.sdk.maven;
+
+import java.net.URI;
+import java.util.Objects;
+import org.eclipse.aether.repository.RemoteRepository;
+
+/**
+ * A Maven remote repository identified by an ID and URL.
+ *
+ * @param id  the repository identifier
+ * @param url the repository URL
+ */
+public record Repository(String id, String url) {
+
+    public Repository {
+        Objects.requireNonNull(url, "Repository URL must not be null");
+        if (id == null || id.isBlank()) {
+            id = deriveId(url);
+        }
+    }
+
+    RemoteRepository toRemoteRepository() {
+        return new RemoteRepository.Builder(id, "default", url).build();
+    }
+
+    private static String deriveId(String url) {
+        String host = URI.create(url).getHost();
+        return host != null ? host : "repo";
+    }
+}

--- a/capabilities-maven-downloader/src/main/java/ai/wanaku/capabilities/sdk/maven/WanakuMavenDownloader.java
+++ b/capabilities-maven-downloader/src/main/java/ai/wanaku/capabilities/sdk/maven/WanakuMavenDownloader.java
@@ -1,0 +1,194 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.wanaku.capabilities.sdk.maven;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import org.eclipse.aether.RepositorySystem;
+import org.eclipse.aether.RepositorySystemSession;
+import org.eclipse.aether.artifact.DefaultArtifact;
+import org.eclipse.aether.collection.CollectRequest;
+import org.eclipse.aether.graph.Dependency;
+import org.eclipse.aether.graph.DependencyFilter;
+import org.eclipse.aether.repository.RemoteRepository;
+import org.eclipse.aether.resolution.ArtifactResult;
+import org.eclipse.aether.resolution.DependencyRequest;
+import org.eclipse.aether.resolution.DependencyResolutionException;
+import org.eclipse.aether.resolution.DependencyResult;
+import org.eclipse.aether.supplier.RepositorySystemSupplier;
+import org.eclipse.aether.supplier.SessionBuilderSupplier;
+import org.eclipse.aether.util.artifact.JavaScopes;
+import org.eclipse.aether.util.filter.DependencyFilterUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Downloads Maven dependencies (including transitive ones) at runtime and makes them
+ * available via a classloader.
+ *
+ * <pre>{@code
+ * try (WanakuMavenDownloader downloader = new WanakuMavenDownloader()) {
+ *     downloader.download(List.of(GAV.parse("org.example:my-lib:1.0")));
+ *     downloader.applyToCurrentThread();
+ *     // classes from my-lib and its dependencies are now loadable
+ * }
+ * }</pre>
+ */
+public class WanakuMavenDownloader implements AutoCloseable {
+    private static final Logger LOG = LoggerFactory.getLogger(WanakuMavenDownloader.class);
+
+    private static final RemoteRepository CENTRAL =
+            new RemoteRepository.Builder("central", "default", "https://repo.maven.apache.org/maven2/").build();
+
+    private final RepositorySystem repositorySystem;
+    private final RepositorySystemSession.CloseableSession session;
+    private final List<RemoteRepository> repositories;
+    private final DynamicClassLoader classLoader;
+
+    /**
+     * Creates a downloader that resolves from Maven Central only, using {@code ~/.m2/repository}
+     * as the local repository.
+     */
+    public WanakuMavenDownloader() {
+        this(Collections.emptyList());
+    }
+
+    /**
+     * Creates a downloader that resolves from Maven Central plus the given extra repositories,
+     * using {@code ~/.m2/repository} as the local repository.
+     *
+     * @param extraRepositories additional remote repositories to resolve from
+     */
+    public WanakuMavenDownloader(List<Repository> extraRepositories) {
+        this(extraRepositories, defaultLocalRepo());
+    }
+
+    /**
+     * Creates a downloader with full control over repositories and local cache path.
+     *
+     * @param extraRepositories additional remote repositories to resolve from
+     * @param localRepository   path to the local Maven repository cache
+     */
+    public WanakuMavenDownloader(List<Repository> extraRepositories, Path localRepository) {
+        Objects.requireNonNull(extraRepositories, "extraRepositories must not be null");
+        Objects.requireNonNull(localRepository, "localRepository must not be null");
+
+        this.repositorySystem = new RepositorySystemSupplier().get();
+        this.session = new SessionBuilderSupplier(repositorySystem)
+                .get()
+                .withLocalRepositoryBaseDirectories(localRepository)
+                .build();
+
+        List<RemoteRepository> repos = new ArrayList<>();
+        repos.add(CENTRAL);
+        for (Repository repo : extraRepositories) {
+            repos.add(repo.toRemoteRepository());
+        }
+        this.repositories = Collections.unmodifiableList(repos);
+
+        this.classLoader = new DynamicClassLoader(WanakuMavenDownloader.class.getClassLoader());
+    }
+
+    /**
+     * Downloads the given artifacts and all their transitive compile-scope dependencies.
+     *
+     * @param gavs the Maven coordinates to resolve
+     * @return paths to all resolved JAR files (including transitive dependencies)
+     * @throws DependencyDownloadException if any dependency cannot be resolved
+     */
+    public List<Path> download(List<GAV> gavs) {
+        Objects.requireNonNull(gavs, "gavs must not be null");
+
+        DependencyFilter filter = DependencyFilterUtils.classpathFilter(JavaScopes.COMPILE, JavaScopes.RUNTIME);
+        List<Path> allPaths = new ArrayList<>();
+
+        for (GAV gav : gavs) {
+            LOG.debug("Resolving {}", gav);
+
+            CollectRequest collectRequest = new CollectRequest();
+            collectRequest.setRoot(new Dependency(
+                    new DefaultArtifact(gav.groupId(), gav.artifactId(), "jar", gav.version()), "compile"));
+            collectRequest.setRepositories(repositories);
+
+            DependencyRequest request = new DependencyRequest(collectRequest, filter);
+
+            DependencyResult result;
+            try {
+                result = repositorySystem.resolveDependencies(session, request);
+            } catch (DependencyResolutionException e) {
+                throw new DependencyDownloadException("Failed to resolve " + gav, e);
+            }
+
+            for (ArtifactResult ar : result.getArtifactResults()) {
+                Path jarPath = ar.getArtifact().getPath();
+                if (jarPath != null) {
+                    allPaths.add(jarPath);
+                    classLoader.addJar(jarPath);
+                    LOG.debug("  resolved {} -> {}", ar.getArtifact(), jarPath);
+                }
+            }
+        }
+
+        return Collections.unmodifiableList(allPaths);
+    }
+
+    /**
+     * Returns the classloader containing all downloaded artifacts.
+     */
+    public ClassLoader getClassLoader() {
+        return classLoader;
+    }
+
+    /**
+     * Sets the current thread's context classloader to include all downloaded artifacts.
+     */
+    public void applyToCurrentThread() {
+        Thread.currentThread().setContextClassLoader(classLoader);
+    }
+
+    @Override
+    public void close() {
+        session.close();
+        repositorySystem.close();
+    }
+
+    private static Path defaultLocalRepo() {
+        return Path.of(System.getProperty("user.home"), ".m2", "repository");
+    }
+
+    private static final class DynamicClassLoader extends URLClassLoader {
+
+        DynamicClassLoader(ClassLoader parent) {
+            super(new URL[0], parent);
+        }
+
+        void addJar(Path jarPath) {
+            try {
+                addURL(jarPath.toUri().toURL());
+            } catch (MalformedURLException e) {
+                throw new IllegalArgumentException("Invalid JAR path: " + jarPath, e);
+            }
+        }
+    }
+}

--- a/capabilities-maven-downloader/src/main/java/ai/wanaku/capabilities/sdk/maven/WanakuMavenDownloader.java
+++ b/capabilities-maven-downloader/src/main/java/ai/wanaku/capabilities/sdk/maven/WanakuMavenDownloader.java
@@ -75,6 +75,14 @@ public class WanakuMavenDownloader implements AutoCloseable {
     }
 
     /**
+     * Creates a downloader that resolves from Maven Central only, using {@code ~/.m2/repository}
+     * as the local repository.
+     */
+    public WanakuMavenDownloader(ClassLoader classLoader) {
+        this(Collections.emptyList(), defaultLocalRepo(), classLoader);
+    }
+
+    /**
      * Creates a downloader that resolves from Maven Central plus the given extra repositories,
      * using {@code ~/.m2/repository} as the local repository.
      *
@@ -91,6 +99,16 @@ public class WanakuMavenDownloader implements AutoCloseable {
      * @param localRepository   path to the local Maven repository cache
      */
     public WanakuMavenDownloader(List<Repository> extraRepositories, Path localRepository) {
+        this(extraRepositories, localRepository, WanakuMavenDownloader.class.getClassLoader());
+    }
+
+    /**
+     * Creates a downloader with full control over repositories and local cache path.
+     *
+     * @param extraRepositories additional remote repositories to resolve from
+     * @param localRepository   path to the local Maven repository cache
+     */
+    public WanakuMavenDownloader(List<Repository> extraRepositories, Path localRepository, ClassLoader classLoader) {
         Objects.requireNonNull(extraRepositories, "extraRepositories must not be null");
         Objects.requireNonNull(localRepository, "localRepository must not be null");
 
@@ -107,7 +125,8 @@ public class WanakuMavenDownloader implements AutoCloseable {
         }
         this.repositories = Collections.unmodifiableList(repos);
 
-        this.classLoader = new DynamicClassLoader(WanakuMavenDownloader.class.getClassLoader());
+        //        this.classLoader = new DynamicClassLoader(WanakuMavenDownloader.class.getClassLoader());
+        this.classLoader = new DynamicClassLoader(classLoader);
     }
 
     /**

--- a/capabilities-maven-downloader/src/test/java/ai/wanaku/capabilities/sdk/maven/GAVTest.java
+++ b/capabilities-maven-downloader/src/test/java/ai/wanaku/capabilities/sdk/maven/GAVTest.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.wanaku.capabilities.sdk.maven;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class GAVTest {
+
+    @Test
+    void parseValidGav() {
+        GAV gav = GAV.parse("org.apache.commons:commons-lang3:3.14.0");
+        assertEquals("org.apache.commons", gav.groupId());
+        assertEquals("commons-lang3", gav.artifactId());
+        assertEquals("3.14.0", gav.version());
+    }
+
+    @Test
+    void parseTrimsWhitespace() {
+        GAV gav = GAV.parse(" org.example : my-lib : 1.0 ");
+        assertEquals("org.example", gav.groupId());
+        assertEquals("my-lib", gav.artifactId());
+        assertEquals("1.0", gav.version());
+    }
+
+    @Test
+    void parseRejectsTooFewParts() {
+        assertThrows(IllegalArgumentException.class, () -> GAV.parse("org.example:my-lib"));
+    }
+
+    @Test
+    void parseRejectsTooManyParts() {
+        assertThrows(IllegalArgumentException.class, () -> GAV.parse("org.example:my-lib:jar:1.0"));
+    }
+
+    @Test
+    void parseRejectsNull() {
+        assertThrows(NullPointerException.class, () -> GAV.parse(null));
+    }
+
+    @Test
+    void toStringRoundTrips() {
+        GAV gav = new GAV("org.example", "my-lib", "1.0");
+        assertEquals("org.example:my-lib:1.0", gav.toString());
+        assertEquals(gav, GAV.parse(gav.toString()));
+    }
+
+    @Test
+    void constructorRejectsNullGroupId() {
+        assertThrows(NullPointerException.class, () -> new GAV(null, "a", "1"));
+    }
+
+    @Test
+    void constructorRejectsNullArtifactId() {
+        assertThrows(NullPointerException.class, () -> new GAV("g", null, "1"));
+    }
+
+    @Test
+    void constructorRejectsNullVersion() {
+        assertThrows(NullPointerException.class, () -> new GAV("g", "a", null));
+    }
+}

--- a/capabilities-maven-downloader/src/test/java/ai/wanaku/capabilities/sdk/maven/WanakuMavenDownloaderTest.java
+++ b/capabilities-maven-downloader/src/test/java/ai/wanaku/capabilities/sdk/maven/WanakuMavenDownloaderTest.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.wanaku.capabilities.sdk.maven;
+
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class WanakuMavenDownloaderTest {
+
+    @TempDir
+    Path tempRepo;
+
+    @Test
+    void constructionWithEmptyReposSucceeds() {
+        try (WanakuMavenDownloader downloader = new WanakuMavenDownloader(Collections.emptyList(), tempRepo)) {
+            assertNotNull(downloader.getClassLoader());
+        }
+    }
+
+    @Test
+    void closeDoesNotThrow() {
+        WanakuMavenDownloader downloader = new WanakuMavenDownloader(Collections.emptyList(), tempRepo);
+        assertDoesNotThrow(downloader::close);
+    }
+
+    @Test
+    void downloadResolvesArtifactAndTransitiveDependencies() {
+        try (WanakuMavenDownloader downloader = new WanakuMavenDownloader(Collections.emptyList(), tempRepo)) {
+            List<Path> paths = downloader.download(List.of(GAV.parse("org.apache.commons:commons-lang3:3.14.0")));
+
+            assertFalse(paths.isEmpty(), "Expected at least one resolved JAR");
+
+            assertDoesNotThrow(
+                    () -> downloader.getClassLoader().loadClass("org.apache.commons.lang3.StringUtils"),
+                    "commons-lang3 class should be loadable");
+        }
+    }
+
+    @Test
+    void downloadThrowsOnInvalidArtifact() {
+        try (WanakuMavenDownloader downloader = new WanakuMavenDownloader(Collections.emptyList(), tempRepo)) {
+            assertThrows(
+                    DependencyDownloadException.class,
+                    () -> downloader.download(List.of(GAV.parse("com.nonexistent:does-not-exist:999.999.999"))));
+        }
+    }
+}

--- a/capabilities-parent/pom.xml
+++ b/capabilities-parent/pom.xml
@@ -35,6 +35,8 @@
         <junit-jupiter.version>5.13.4</junit-jupiter.version>
         <oauth2-oidc-sdk.version>11.37</oauth2-oidc-sdk.version>
         <langchain4j.version>1.12.2</langchain4j.version>
+        <maven.resolver.version>2.0.16</maven.resolver.version>
+        <maven.resolver-provider.version>3.9.9</maven.resolver-provider.version>
         <mockito.version>5.23.0</mockito.version>
         <palantir-java-format.version>2.71.0</palantir-java-format.version>
     </properties>

--- a/capabilities-runtimes/capabilities-runtimes-camel/capabilities-runtimes-camel-common/pom.xml
+++ b/capabilities-runtimes/capabilities-runtimes-camel/capabilities-runtimes-camel-common/pom.xml
@@ -54,11 +54,6 @@
         </dependency>
         <dependency>
             <groupId>org.apache.camel</groupId>
-            <artifactId>camel-kamelet-main</artifactId>
-            <version>${camel.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.camel</groupId>
             <artifactId>camel-direct</artifactId>
             <version>${camel.version}</version>
         </dependency>

--- a/capabilities-runtimes/capabilities-runtimes-camel/capabilities-runtimes-camel-common/src/main/java/ai/wanaku/capabilities/sdk/runtime/camel/downloader/ResourceType.java
+++ b/capabilities-runtimes/capabilities-runtimes-camel/capabilities-runtimes-camel-common/src/main/java/ai/wanaku/capabilities/sdk/runtime/camel/downloader/ResourceType.java
@@ -4,4 +4,5 @@ public enum ResourceType {
     ROUTES_REF,
     RULES_REF,
     DEPENDENCY_REF,
+    PROPERTIES_REF,
 }

--- a/capabilities-runtimes/capabilities-runtimes-camel/capabilities-runtimes-camel-common/src/main/java/ai/wanaku/capabilities/sdk/runtime/camel/downloader/ServiceCatalogExtractor.java
+++ b/capabilities-runtimes/capabilities-runtimes-camel/capabilities-runtimes-camel-common/src/main/java/ai/wanaku/capabilities/sdk/runtime/camel/downloader/ServiceCatalogExtractor.java
@@ -68,6 +68,9 @@ public final class ServiceCatalogExtractor {
             entriesToExtract.put(depsEntry.trim(), ResourceType.DEPENDENCY_REF);
         }
 
+        String propsEntry = system + "/service.properties";
+        entriesToExtract.put(propsEntry, ResourceType.PROPERTIES_REF);
+
         Map<ResourceType, Path> result = extractEntries(zipBytes, entriesToExtract, dataDir);
 
         if (!result.containsKey(ResourceType.ROUTES_REF)) {

--- a/capabilities-runtimes/capabilities-runtimes-camel/capabilities-runtimes-camel-common/src/main/java/ai/wanaku/capabilities/sdk/runtime/camel/util/WanakuRoutesLoader.java
+++ b/capabilities-runtimes/capabilities-runtimes-camel/capabilities-runtimes-camel-common/src/main/java/ai/wanaku/capabilities/sdk/runtime/camel/util/WanakuRoutesLoader.java
@@ -26,24 +26,10 @@ import java.util.Properties;
 import java.util.ServiceLoader;
 import org.apache.camel.CamelContext;
 import org.apache.camel.ExtendedCamelContext;
-import org.apache.camel.main.download.DependencyDownloader;
-import org.apache.camel.main.download.DependencyDownloaderClassLoader;
-import org.apache.camel.main.download.DependencyDownloaderComponentResolver;
-import org.apache.camel.main.download.DependencyDownloaderDataFormatResolver;
-import org.apache.camel.main.download.DependencyDownloaderLanguageResolver;
-import org.apache.camel.main.download.DependencyDownloaderRoutesLoader;
-import org.apache.camel.main.download.DependencyDownloaderTransformerResolver;
-import org.apache.camel.main.download.DependencyDownloaderUriFactoryResolver;
-import org.apache.camel.main.download.MavenDependencyDownloader;
-import org.apache.camel.spi.ComponentResolver;
 import org.apache.camel.spi.ContextServicePlugin;
-import org.apache.camel.spi.DataFormatResolver;
-import org.apache.camel.spi.LanguageResolver;
 import org.apache.camel.spi.Resource;
 import org.apache.camel.spi.ResourceLoader;
 import org.apache.camel.spi.RoutesLoader;
-import org.apache.camel.spi.TransformerResolver;
-import org.apache.camel.spi.UriFactoryResolver;
 import org.apache.camel.support.PluginHelper;
 import org.slf4j.Logger;
 import ai.wanaku.capabilities.sdk.runtime.camel.exceptions.RouteLoadingException;
@@ -59,25 +45,10 @@ import ai.wanaku.capabilities.sdk.runtime.camel.exceptions.RouteLoadingException
 public class WanakuRoutesLoader {
     private static final Logger LOG = org.slf4j.LoggerFactory.getLogger(WanakuRoutesLoader.class);
 
-    private final String dependenciesList;
-    private final String repositoriesList;
-    private final DependencyDownloaderClassLoader cl;
-    private final MavenDependencyDownloader downloader;
-
     /**
      * Creates a new loader.
-     *
-     * @param dependenciesList comma-separated Maven coordinates ({@code group:artifact:version}) to
-     *                         download before loading routes, or {@code null} for none
-     * @param repositoriesList comma-separated Maven repository URLs to resolve dependencies from,
-     *                         or {@code null} to use the default repositories
      */
-    public WanakuRoutesLoader(String dependenciesList, String repositoriesList) {
-        this.dependenciesList = dependenciesList;
-        this.repositoriesList = repositoriesList;
-        this.cl = createClassLoader();
-        this.downloader = createDownloader(cl);
-    }
+    public WanakuRoutesLoader() {}
 
     /**
      * Downloads required dependencies, registers dependency-aware resolvers on the given context,
@@ -90,28 +61,6 @@ public class WanakuRoutesLoader {
     public void loadRoute(CamelContext context, String path) {
         final ExtendedCamelContext camelContextExtension = context.getCamelContextExtension();
 
-        try {
-            context.addService(downloader);
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        }
-
-        camelContextExtension.addContextPlugin(
-                ComponentResolver.class, new DependencyDownloaderComponentResolver(context, null, false, false));
-        camelContextExtension.addContextPlugin(
-                DataFormatResolver.class, new DependencyDownloaderDataFormatResolver(context, null, false));
-        camelContextExtension.addContextPlugin(
-                LanguageResolver.class, new DependencyDownloaderLanguageResolver(context, null, false));
-        camelContextExtension.addContextPlugin(
-                TransformerResolver.class, new DependencyDownloaderTransformerResolver(context, null, false));
-        camelContextExtension.addContextPlugin(
-                UriFactoryResolver.class, new DependencyDownloaderUriFactoryResolver(context));
-
-        downloadDependencies(context);
-
-        DependencyDownloaderRoutesLoader loader = new DependencyDownloaderRoutesLoader(context);
-        camelContextExtension.addContextPlugin(RoutesLoader.class, loader);
-
         loadServiceProperties(context, path);
         discoverAndLoadPlugins(context);
 
@@ -119,53 +68,12 @@ public class WanakuRoutesLoader {
         final Resource resource = resourceLoader.resolveResource(path);
 
         try {
-            loader.loadRoutes(resource);
+            camelContextExtension.getContextPlugin(RoutesLoader.class).loadRoutes(resource);
         } catch (Exception e) {
             throw new RouteLoadingException(path, e);
         }
 
         context.build();
-    }
-
-    /**
-     * Downloads each dependency from {@link #dependenciesList} using the Maven downloader and
-     * registers the downloader as a context plugin.
-     */
-    private void downloadDependencies(CamelContext camelContext) {
-        ExtendedCamelContext camelContextExtension = camelContext.getCamelContextExtension();
-
-        if (dependenciesList != null) {
-            final String[] dependencies = dependenciesList.split(",");
-            for (String dependency : dependencies) {
-                // In case of empty file
-                if (!dependency.isEmpty()) {
-                    dependency = dependency.trim();
-                    downloader.downloadDependency(
-                            GavUtil.group(dependency), GavUtil.artifact(dependency), GavUtil.version(dependency));
-                }
-            }
-
-            cl.getDownloaded().forEach(d -> LOG.debug("Downloaded {}", d));
-        }
-
-        Thread.currentThread().setContextClassLoader(cl);
-        camelContextExtension.addContextPlugin(DependencyDownloader.class, downloader);
-    }
-
-    /**
-     * Creates and starts a {@link MavenDependencyDownloader} configured with the given class loader
-     * and optional custom repositories.
-     */
-    private MavenDependencyDownloader createDownloader(DependencyDownloaderClassLoader cl) {
-        MavenDependencyDownloader downloader = new MavenDependencyDownloader();
-        downloader.setClassLoader(cl);
-
-        if (repositoriesList != null) {
-            downloader.setRepositories(repositoriesList);
-        }
-
-        downloader.start();
-        return downloader;
     }
 
     private void loadServiceProperties(CamelContext context, String routePath) {
@@ -195,8 +103,8 @@ public class WanakuRoutesLoader {
     }
 
     private void discoverAndLoadPlugins(CamelContext context) {
-        ClassLoader depClassLoader = Thread.currentThread().getContextClassLoader();
-        ServiceLoader<ContextServicePlugin> plugins = ServiceLoader.load(ContextServicePlugin.class, depClassLoader);
+        ServiceLoader<ContextServicePlugin> plugins =
+                ServiceLoader.load(ContextServicePlugin.class, context.getApplicationContextClassLoader());
 
         for (ContextServicePlugin plugin : plugins) {
             if (plugin.getClass().getClassLoader() != WanakuRoutesLoader.class.getClassLoader()) {
@@ -204,12 +112,5 @@ public class WanakuRoutesLoader {
                 plugin.load(context);
             }
         }
-    }
-
-    /** Creates a child class loader that the dependency downloader will add downloaded JARs to. */
-    private static DependencyDownloaderClassLoader createClassLoader() {
-        final ClassLoader parentCL = WanakuRoutesLoader.class.getClassLoader();
-
-        return new DependencyDownloaderClassLoader(parentCL);
     }
 }

--- a/capabilities-runtimes/capabilities-runtimes-camel/capabilities-runtimes-camel-common/src/main/java/ai/wanaku/capabilities/sdk/runtime/camel/util/WanakuRoutesLoader.java
+++ b/capabilities-runtimes/capabilities-runtimes-camel/capabilities-runtimes-camel-common/src/main/java/ai/wanaku/capabilities/sdk/runtime/camel/util/WanakuRoutesLoader.java
@@ -17,6 +17,13 @@
 
 package ai.wanaku.capabilities.sdk.runtime.camel.util;
 
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Properties;
+import java.util.ServiceLoader;
 import org.apache.camel.CamelContext;
 import org.apache.camel.ExtendedCamelContext;
 import org.apache.camel.main.download.DependencyDownloader;
@@ -29,6 +36,7 @@ import org.apache.camel.main.download.DependencyDownloaderTransformerResolver;
 import org.apache.camel.main.download.DependencyDownloaderUriFactoryResolver;
 import org.apache.camel.main.download.MavenDependencyDownloader;
 import org.apache.camel.spi.ComponentResolver;
+import org.apache.camel.spi.ContextServicePlugin;
 import org.apache.camel.spi.DataFormatResolver;
 import org.apache.camel.spi.LanguageResolver;
 import org.apache.camel.spi.Resource;
@@ -104,6 +112,9 @@ public class WanakuRoutesLoader {
         DependencyDownloaderRoutesLoader loader = new DependencyDownloaderRoutesLoader(context);
         camelContextExtension.addContextPlugin(RoutesLoader.class, loader);
 
+        loadServiceProperties(context, path);
+        discoverAndLoadPlugins(context);
+
         final ResourceLoader resourceLoader = PluginHelper.getResourceLoader(context);
         final Resource resource = resourceLoader.resolveResource(path);
 
@@ -155,6 +166,44 @@ public class WanakuRoutesLoader {
 
         downloader.start();
         return downloader;
+    }
+
+    private void loadServiceProperties(CamelContext context, String routePath) {
+        Path routeFile = Path.of(URI.create(routePath));
+        Path serviceProps = routeFile.getParent().resolve("service.properties");
+
+        if (!Files.exists(serviceProps)) {
+            return;
+        }
+
+        context.getPropertiesComponent().addLocation("file:" + serviceProps.toAbsolutePath());
+        LOG.info("Registered service.properties as Camel property source: {}", serviceProps);
+
+        try (InputStream is = Files.newInputStream(serviceProps)) {
+            Properties props = new Properties();
+            props.load(is);
+
+            for (String key : props.stringPropertyNames()) {
+                if (key.startsWith("forage.")) {
+                    System.setProperty(key, props.getProperty(key));
+                    LOG.debug("Set system property from service.properties: {}", key);
+                }
+            }
+        } catch (IOException e) {
+            LOG.warn("Failed to load service.properties: {}", e.getMessage());
+        }
+    }
+
+    private void discoverAndLoadPlugins(CamelContext context) {
+        ClassLoader depClassLoader = Thread.currentThread().getContextClassLoader();
+        ServiceLoader<ContextServicePlugin> plugins = ServiceLoader.load(ContextServicePlugin.class, depClassLoader);
+
+        for (ContextServicePlugin plugin : plugins) {
+            if (plugin.getClass().getClassLoader() != WanakuRoutesLoader.class.getClassLoader()) {
+                LOG.info("Loading discovered plugin: {}", plugin.getClass().getName());
+                plugin.load(context);
+            }
+        }
     }
 
     /** Creates a child class loader that the dependency downloader will add downloaded JARs to. */

--- a/capabilities-runtimes/capabilities-runtimes-camel/capabilities-runtimes-camel-common/src/test/java/ai/wanaku/capabilities/sdk/runtime/camel/downloader/ServiceCatalogExtractorTest.java
+++ b/capabilities-runtimes/capabilities-runtimes-camel/capabilities-runtimes-camel-common/src/test/java/ai/wanaku/capabilities/sdk/runtime/camel/downloader/ServiceCatalogExtractorTest.java
@@ -49,6 +49,21 @@ class ServiceCatalogExtractorTest {
     }
 
     @Test
+    void testExtractWithServiceProperties() throws Exception {
+        String base64Zip = createTestZipWithProperties("test-catalog", "sys1");
+        Map<ResourceType, Path> result = ServiceCatalogExtractor.extract(base64Zip, "sys1", tempDir);
+
+        assertTrue(result.containsKey(ResourceType.PROPERTIES_REF));
+        assertTrue(Files.exists(result.get(ResourceType.PROPERTIES_REF)));
+
+        Properties extracted = new Properties();
+        try (var is = Files.newInputStream(result.get(ResourceType.PROPERTIES_REF))) {
+            extracted.load(is);
+        }
+        assertEquals("test-api-key", extracted.getProperty("forage.tavily.api.key"));
+    }
+
+    @Test
     void testExtractUnknownSystem() {
         String base64Zip = createTestZip("test-catalog", "sys1");
         assertThrows(WanakuException.class, () -> ServiceCatalogExtractor.extract(base64Zip, "nonexistent", tempDir));
@@ -82,6 +97,46 @@ class ServiceCatalogExtractorTest {
 
     private String createTestZipWithDeps(String name, String... systems) {
         return createTestZipInternal(name, true, systems);
+    }
+
+    private String createTestZipWithProperties(String name, String... systems) {
+        try {
+            ByteArrayOutputStream baos = new ByteArrayOutputStream();
+            try (ZipOutputStream zos = new ZipOutputStream(baos)) {
+                Properties props = new Properties();
+                props.setProperty("catalog.name", name);
+                props.setProperty("catalog.description", "Test catalog");
+                props.setProperty("catalog.services", String.join(",", systems));
+
+                for (String sys : systems) {
+                    String routesPath = sys + "/" + sys + ".camel.yaml";
+                    String rulesPath = sys + "/" + sys + ".wanaku-rules.yaml";
+                    props.setProperty("catalog.routes." + sys, routesPath);
+                    props.setProperty("catalog.rules." + sys, rulesPath);
+
+                    zos.putNextEntry(new ZipEntry(routesPath));
+                    zos.write(("# Routes for " + sys).getBytes());
+                    zos.closeEntry();
+
+                    zos.putNextEntry(new ZipEntry(rulesPath));
+                    zos.write(("# Rules for " + sys).getBytes());
+                    zos.closeEntry();
+
+                    zos.putNextEntry(new ZipEntry(sys + "/service.properties"));
+                    zos.write("forage.tavily.api.key=test-api-key\n".getBytes());
+                    zos.closeEntry();
+                }
+
+                zos.putNextEntry(new ZipEntry("index.properties"));
+                ByteArrayOutputStream propsOut = new ByteArrayOutputStream();
+                props.store(propsOut, null);
+                zos.write(propsOut.toByteArray());
+                zos.closeEntry();
+            }
+            return Base64.getEncoder().encodeToString(baos.toByteArray());
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
     }
 
     private String createTestZipInternal(String name, boolean includeDeps, String... systems) {

--- a/pom.xml
+++ b/pom.xml
@@ -76,6 +76,7 @@
         <module>capabilities-runtimes</module>
         <module>capabilities-services-client</module>
         <module>capabilities-code-execution-engines</module>
+        <module>capabilities-maven-downloader</module>
         <module>capabilities-bom</module>
         <module>capabilities-archetypes</module>
         <module>capabilities-api</module>


### PR DESCRIPTION
- **Add Forage support to WanakuRoutesLoader**
- **Add capabilities-maven-downloader module for runtime dependency resolution**
- **Refactor the code to use our own dependency downloader**

## Summary by Sourcery

Introduce a standalone Maven-based runtime dependency downloader module and integrate it into the Camel runtime while adding support for loading Forage configuration from service properties.

New Features:
- Add a capabilities-maven-downloader module to resolve and load Maven artifacts at runtime using Maven Resolver.
- Load service.properties alongside routes to configure Forage-related system properties in the Camel runtime.
- Automatically discover and load context service plugins via ServiceLoader when loading routes.

Enhancements:
- Refactor WanakuRoutesLoader to remove tight coupling to the previous Camel dependency downloader and rely on plugin-based route loading.
- Extend service catalog extraction to include service.properties files and track them via a new PROPERTIES_REF resource type.

Build:
- Add the capabilities-maven-downloader module to the multi-module build and BOM, and declare Maven Resolver dependencies and versions in the parent POM.

Tests:
- Add unit tests for the new Maven downloader utilities (GAV parsing and WanakuMavenDownloader behavior).
- Extend ServiceCatalogExtractor tests to cover extraction and validation of service.properties content.