### PR TITLE
chore: close URLClassLoader in WanakuMavenDownloader to fix Windows CI

### DIFF
--- a/capabilities-maven-downloader/src/main/java/ai/wanaku/capabilities/sdk/maven/WanakuMavenDownloader.java
+++ b/capabilities-maven-downloader/src/main/java/ai/wanaku/capabilities/sdk/maven/WanakuMavenDownloader.java
@@ -17,6 +17,7 @@
 
 package ai.wanaku.capabilities.sdk.maven;
 
+import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLClassLoader;
@@ -187,6 +188,11 @@ public class WanakuMavenDownloader implements AutoCloseable {
 
     @Override
     public void close() {
+        try {
+            classLoader.close();
+        } catch (IOException e) {
+            LOG.warn("Failed to close classloader: {}", e.getMessage());
+        }
         session.close();
         repositorySystem.close();
     }


### PR DESCRIPTION
## Summary
- PRs #132 and #127 failed on `build (windows-latest, true)` with `FileSystemException: The process cannot access the file because it is being used by another process`
- Root cause: `WanakuMavenDownloader.close()` was not closing the `DynamicClassLoader` (a `URLClassLoader`), leaving open file handles on downloaded JARs in the temp directory
- On Windows, open file handles prevent file deletion, so JUnit's `@TempDir` cleanup failed
- Fix: close the classloader before closing the session and repository system

## Test plan
- [x] Full `mvn verify` passes locally
- [x] Full reactor `mvn clean install -DskipTests` passes
- [ ] Windows CI build passes (verified by PR checks)

## Summary by Sourcery

Bug Fixes:
- Close the DynamicClassLoader/URLClassLoader in WanakuMavenDownloader.close() to prevent open file handles from blocking temp file cleanup, particularly on Windows.