### PR TITLE
Fix wanaku-ai/wanaku#1086: fix domain model quality

### DIFF
--- a/capabilities-api/src/main/java/ai/wanaku/capabilities/sdk/api/types/ResourceReference.java
+++ b/capabilities-api/src/main/java/ai/wanaku/capabilities/sdk/api/types/ResourceReference.java
@@ -270,6 +270,23 @@ public class ResourceReference extends LabelsAwareEntity<String> {
         public void setValue(String value) {
             this.value = value;
         }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            Param param = (Param) o;
+            return Objects.equals(name, param.name) && Objects.equals(value, param.value);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(name, value);
+        }
     }
 
     @Override

--- a/capabilities-api/src/main/java/ai/wanaku/capabilities/sdk/api/types/ToolReference.java
+++ b/capabilities-api/src/main/java/ai/wanaku/capabilities/sdk/api/types/ToolReference.java
@@ -69,14 +69,12 @@ public class ToolReference extends LabelsAwareEntity<String> implements Callable
     }
 
     /**
-     * Sets the URI of the tool reference and returns the current object for method chaining.
+     * Sets the URI of the tool reference.
      *
      * @param uri the new URI of the tool reference
-     * @return the current ToolReference object
      */
-    public ToolReference setUri(String uri) {
+    public void setUri(String uri) {
         this.uri = uri;
-        return this;
     }
 
     /**
@@ -90,14 +88,12 @@ public class ToolReference extends LabelsAwareEntity<String> implements Callable
     }
 
     /**
-     * Sets the type of the tool reference and returns the current object for method chaining.
+     * Sets the type of the tool reference.
      *
      * @param type the new type of the tool reference
-     * @return the current ToolReference object
      */
-    public ToolReference setType(String type) {
+    public void setType(String type) {
         this.type = type;
-        return this;
     }
 
     /**


### PR DESCRIPTION
## Summary
- Add equals() and hashCode() to ResourceReference.Param
- Standardize setter return types to void (remove fluent chaining from setters)

Fixes wanaku-ai/wanaku#1086

## Summary by Sourcery

Align domain model semantics for capability resource and tool references.

Enhancements:
- Implement equality and hash code for ResourceReference.Param based on name and value.
- Standardize ToolReference setters to return void instead of supporting fluent chaining.