### PR TITLE
Fix #135: add JSpecify nullness annotations to capabilities-api

### DIFF
--- a/capabilities-api/pom.xml
+++ b/capabilities-api/pom.xml
@@ -13,6 +13,10 @@
 
     <dependencies>
         <dependency>
+            <groupId>org.jspecify</groupId>
+            <artifactId>jspecify</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
         </dependency>

--- a/capabilities-api/src/main/java/ai/wanaku/capabilities/sdk/api/discovery/package-info.java
+++ b/capabilities-api/src/main/java/ai/wanaku/capabilities/sdk/api/discovery/package-info.java
@@ -1,0 +1,4 @@
+@NullMarked
+package ai.wanaku.capabilities.sdk.api.discovery;
+
+import org.jspecify.annotations.NullMarked;

--- a/capabilities-api/src/main/java/ai/wanaku/capabilities/sdk/api/exceptions/package-info.java
+++ b/capabilities-api/src/main/java/ai/wanaku/capabilities/sdk/api/exceptions/package-info.java
@@ -1,0 +1,4 @@
+@NullMarked
+package ai.wanaku.capabilities.sdk.api.exceptions;
+
+import org.jspecify.annotations.NullMarked;

--- a/capabilities-api/src/main/java/ai/wanaku/capabilities/sdk/api/types/DataStore.java
+++ b/capabilities-api/src/main/java/ai/wanaku/capabilities/sdk/api/types/DataStore.java
@@ -1,6 +1,7 @@
 package ai.wanaku.capabilities.sdk.api.types;
 
 import java.util.Objects;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Entity representing a data store entry for persisting arbitrary binary or text data.
@@ -77,7 +78,7 @@ public class DataStore extends LabelsAwareEntity<String> {
      * @return the ID, or {@code null} if not yet persisted
      */
     @Override
-    public String getId() {
+    public @Nullable String getId() {
         return id;
     }
 

--- a/capabilities-api/src/main/java/ai/wanaku/capabilities/sdk/api/types/InputSchema.java
+++ b/capabilities-api/src/main/java/ai/wanaku/capabilities/sdk/api/types/InputSchema.java
@@ -4,15 +4,16 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Represents the input schema for a tool, including type, properties, and required fields.
  */
 public class InputSchema {
 
-    private String type;
+    private @Nullable String type;
     private Map<String, Property> properties = new HashMap<>();
-    private List<String> required;
+    private @Nullable List<String> required;
 
     /**
      * Default constructor for InputSchema.
@@ -24,7 +25,7 @@ public class InputSchema {
      *
      * @return the type of the input schema
      */
-    public String getType() {
+    public @Nullable String getType() {
         return type;
     }
 
@@ -60,7 +61,7 @@ public class InputSchema {
      *
      * @return a list of required field names
      */
-    public List<String> getRequired() {
+    public @Nullable List<String> getRequired() {
         return required;
     }
 

--- a/capabilities-api/src/main/java/ai/wanaku/capabilities/sdk/api/types/LabelsAwareEntity.java
+++ b/capabilities-api/src/main/java/ai/wanaku/capabilities/sdk/api/types/LabelsAwareEntity.java
@@ -2,6 +2,7 @@ package ai.wanaku.capabilities.sdk.api.types;
 
 import java.util.HashMap;
 import java.util.Map;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Abstract base class for Wanaku entities that support labels.
@@ -19,7 +20,7 @@ public abstract class LabelsAwareEntity<T> implements WanakuEntity<T> {
      */
     protected LabelsAwareEntity() {}
 
-    private Map<String, String> labels;
+    private @Nullable Map<String, String> labels;
 
     /**
      * Gets the labels as a map.
@@ -57,7 +58,7 @@ public abstract class LabelsAwareEntity<T> implements WanakuEntity<T> {
      *
      * @param labelsMap the labels to add
      */
-    public void addLabels(Map<String, String> labelsMap) {
+    public void addLabels(@Nullable Map<String, String> labelsMap) {
         if (labelsMap != null) {
             getLabels().putAll(labelsMap);
         }
@@ -69,7 +70,7 @@ public abstract class LabelsAwareEntity<T> implements WanakuEntity<T> {
      * @param labelKey the label key to look up
      * @return the label value, or null if not found
      */
-    public String getLabelValue(String labelKey) {
+    public @Nullable String getLabelValue(String labelKey) {
         if (labels == null) {
             return null;
         }

--- a/capabilities-api/src/main/java/ai/wanaku/capabilities/sdk/api/types/PromptMessage.java
+++ b/capabilities-api/src/main/java/ai/wanaku/capabilities/sdk/api/types/PromptMessage.java
@@ -1,6 +1,7 @@
 package ai.wanaku.capabilities.sdk.api.types;
 
 import java.util.Objects;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Represents a message in an MCP prompt.
@@ -11,7 +12,7 @@ public class PromptMessage {
      * The role of the message sender.
      * Valid values: "user", "assistant"
      */
-    private String role;
+    private @Nullable String role;
 
     /**
      * The content of the message.
@@ -21,7 +22,7 @@ public class PromptMessage {
      * - AudioContent
      * - EmbeddedResource
      */
-    private PromptContent content;
+    private @Nullable PromptContent content;
 
     /**
      * Default constructor for serialization frameworks.
@@ -44,7 +45,7 @@ public class PromptMessage {
      *
      * @return the role
      */
-    public String getRole() {
+    public @Nullable String getRole() {
         return role;
     }
 
@@ -62,7 +63,7 @@ public class PromptMessage {
      *
      * @return the message content
      */
-    public PromptContent getContent() {
+    public @Nullable PromptContent getContent() {
         return content;
     }
 

--- a/capabilities-api/src/main/java/ai/wanaku/capabilities/sdk/api/types/PromptReference.java
+++ b/capabilities-api/src/main/java/ai/wanaku/capabilities/sdk/api/types/PromptReference.java
@@ -2,6 +2,7 @@ package ai.wanaku.capabilities.sdk.api.types;
 
 import java.util.List;
 import java.util.Objects;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Represents a prompt reference in the MCP protocol.
@@ -30,17 +31,17 @@ public class PromptReference implements WanakuEntity<String> {
      * The prompt messages following MCP specification.
      * Each message has a role (user, assistant) and content.
      */
-    private List<PromptMessage> messages;
+    private @Nullable List<PromptMessage> messages;
 
     /**
      * List of arguments/parameters this prompt accepts.
      */
-    private List<PromptArgument> arguments;
+    private @Nullable List<PromptArgument> arguments;
 
     /**
      * Optional list of tool names that this prompt may use.
      */
-    private List<String> toolReferences;
+    private @Nullable List<String> toolReferences;
 
     /**
      * The namespace this prompt belongs to.
@@ -103,7 +104,7 @@ public class PromptReference implements WanakuEntity<String> {
      *
      * @return the list of prompt messages
      */
-    public List<PromptMessage> getMessages() {
+    public @Nullable List<PromptMessage> getMessages() {
         return messages;
     }
 
@@ -121,7 +122,7 @@ public class PromptReference implements WanakuEntity<String> {
      *
      * @return the list of prompt arguments
      */
-    public List<PromptArgument> getArguments() {
+    public @Nullable List<PromptArgument> getArguments() {
         return arguments;
     }
 
@@ -139,7 +140,7 @@ public class PromptReference implements WanakuEntity<String> {
      *
      * @return the list of tool references
      */
-    public List<String> getToolReferences() {
+    public @Nullable List<String> getToolReferences() {
         return toolReferences;
     }
 

--- a/capabilities-api/src/main/java/ai/wanaku/capabilities/sdk/api/types/ResourceReference.java
+++ b/capabilities-api/src/main/java/ai/wanaku/capabilities/sdk/api/types/ResourceReference.java
@@ -2,6 +2,7 @@ package ai.wanaku.capabilities.sdk.api.types;
 
 import java.util.List;
 import java.util.Objects;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Represents a resource reference, containing details such as location, type, and parameters.
@@ -42,10 +43,10 @@ public class ResourceReference extends LabelsAwareEntity<String> {
     /**
      * A list of parameters associated with the resource.
      */
-    private List<Param> params;
+    private @Nullable List<Param> params;
 
-    private String configurationURI;
-    private String secretsURI;
+    private @Nullable String configurationURI;
+    private @Nullable String secretsURI;
     private String namespace;
 
     /**
@@ -143,7 +144,7 @@ public class ResourceReference extends LabelsAwareEntity<String> {
      *
      * @return the list of resource parameters
      */
-    public List<Param> getParams() {
+    public @Nullable List<Param> getParams() {
         return params;
     }
 
@@ -164,7 +165,7 @@ public class ResourceReference extends LabelsAwareEntity<String> {
      *
      * @return the configuration URI, or {@code null} if not configured
      */
-    public String getConfigurationURI() {
+    public @Nullable String getConfigurationURI() {
         return configurationURI;
     }
 
@@ -185,7 +186,7 @@ public class ResourceReference extends LabelsAwareEntity<String> {
      *
      * @return the secrets URI, or {@code null} if not configured
      */
-    public String getSecretsURI() {
+    public @Nullable String getSecretsURI() {
         return secretsURI;
     }
 

--- a/capabilities-api/src/main/java/ai/wanaku/capabilities/sdk/api/types/ToolReference.java
+++ b/capabilities-api/src/main/java/ai/wanaku/capabilities/sdk/api/types/ToolReference.java
@@ -1,6 +1,7 @@
 package ai.wanaku.capabilities.sdk.api.types;
 
 import java.util.Objects;
+import org.jspecify.annotations.Nullable;
 
 /**
  * This class represents a reference to a tool with various attributes such as name, description, URI, type, and input schema.
@@ -13,8 +14,8 @@ public class ToolReference extends LabelsAwareEntity<String> implements Callable
     private String type;
     private InputSchema inputSchema;
     private String namespace;
-    private String configurationURI;
-    private String secretsURI;
+    private @Nullable String configurationURI;
+    private @Nullable String secretsURI;
 
     /**
      * Default constructor for ToolReference.
@@ -142,7 +143,7 @@ public class ToolReference extends LabelsAwareEntity<String> implements Callable
      *
      * @return the configuration URI, or {@code null} if not configured
      */
-    public String getConfigurationURI() {
+    public @Nullable String getConfigurationURI() {
         return configurationURI;
     }
 
@@ -163,7 +164,7 @@ public class ToolReference extends LabelsAwareEntity<String> implements Callable
      *
      * @return the secrets URI, or {@code null} if not configured
      */
-    public String getSecretsURI() {
+    public @Nullable String getSecretsURI() {
         return secretsURI;
     }
 

--- a/capabilities-api/src/main/java/ai/wanaku/capabilities/sdk/api/types/WanakuEntity.java
+++ b/capabilities-api/src/main/java/ai/wanaku/capabilities/sdk/api/types/WanakuEntity.java
@@ -1,5 +1,7 @@
 package ai.wanaku.capabilities.sdk.api.types;
 
+import org.jspecify.annotations.Nullable;
+
 /**
  * Base interface for all Wanaku entity types.
  * <p>
@@ -16,7 +18,7 @@ public interface WanakuEntity<K> {
      *
      * @return the entity identifier, or {@code null} if not yet assigned
      */
-    K getId();
+    @Nullable K getId();
 
     /**
      * Sets the unique identifier for this entity.

--- a/capabilities-api/src/main/java/ai/wanaku/capabilities/sdk/api/types/WanakuError.java
+++ b/capabilities-api/src/main/java/ai/wanaku/capabilities/sdk/api/types/WanakuError.java
@@ -1,5 +1,7 @@
 package ai.wanaku.capabilities.sdk.api.types;
 
+import org.jspecify.annotations.Nullable;
+
 /**
  * Represents an error response from the Wanaku API or services.
  * <p>
@@ -12,7 +14,7 @@ package ai.wanaku.capabilities.sdk.api.types;
  *
  * @param message the error message describing what went wrong, or {@code null} if no message is available
  */
-public record WanakuError(String message) {
+public record WanakuError(@Nullable String message) {
 
     /**
      * Default constructor that creates a {@link WanakuError} with no message.

--- a/capabilities-api/src/main/java/ai/wanaku/capabilities/sdk/api/types/WanakuResponse.java
+++ b/capabilities-api/src/main/java/ai/wanaku/capabilities/sdk/api/types/WanakuResponse.java
@@ -1,5 +1,7 @@
 package ai.wanaku.capabilities.sdk.api.types;
 
+import org.jspecify.annotations.Nullable;
+
 /**
  * Represents a Wanaku response, which can contain either an error or data.
  *
@@ -7,7 +9,7 @@ package ai.wanaku.capabilities.sdk.api.types;
  * @param error An optional error to include in the response
  * @param data The data to include in the response.
  */
-public record WanakuResponse<T>(WanakuError error, T data) {
+public record WanakuResponse<T>(@Nullable WanakuError error, @Nullable T data) {
 
     /**
      * Creates a new Wanaku response with no error and no data.

--- a/capabilities-api/src/main/java/ai/wanaku/capabilities/sdk/api/types/discovery/ActivityRecord.java
+++ b/capabilities-api/src/main/java/ai/wanaku/capabilities/sdk/api/types/discovery/ActivityRecord.java
@@ -5,6 +5,7 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import org.jspecify.annotations.Nullable;
 import ai.wanaku.capabilities.sdk.api.types.WanakuEntity;
 
 /**
@@ -22,7 +23,7 @@ public class ActivityRecord implements WanakuEntity<String> {
     public static final int TIME_TO_LET_GO = 10;
 
     private String id;
-    private Instant lastSeen;
+    private @Nullable Instant lastSeen;
     private HealthStatus healthStatus = HealthStatus.PENDING;
     private List<ServiceState> states = new ArrayList<>();
 
@@ -56,7 +57,7 @@ public class ActivityRecord implements WanakuEntity<String> {
      *
      * @return the last seen timestamp, or {@code null} if never observed
      */
-    public Instant getLastSeen() {
+    public @Nullable Instant getLastSeen() {
         return lastSeen;
     }
 

--- a/capabilities-api/src/main/java/ai/wanaku/capabilities/sdk/api/types/discovery/HealthStatus.java
+++ b/capabilities-api/src/main/java/ai/wanaku/capabilities/sdk/api/types/discovery/HealthStatus.java
@@ -1,5 +1,7 @@
 package ai.wanaku.capabilities.sdk.api.types.discovery;
 
+import org.jspecify.annotations.Nullable;
+
 /**
  * Represents the health status of a service in the Wanaku system.
  */
@@ -30,7 +32,7 @@ public enum HealthStatus {
      * @param value the string value to convert
      * @return the matching HealthStatus, or {@link #PENDING} if no match is found or value is null
      */
-    public static HealthStatus fromValue(String value) {
+    public static HealthStatus fromValue(@Nullable String value) {
         if (value == null) {
             return PENDING;
         }

--- a/capabilities-api/src/main/java/ai/wanaku/capabilities/sdk/api/types/discovery/ServiceState.java
+++ b/capabilities-api/src/main/java/ai/wanaku/capabilities/sdk/api/types/discovery/ServiceState.java
@@ -2,6 +2,7 @@ package ai.wanaku.capabilities.sdk.api.types.discovery;
 
 import java.time.Instant;
 import java.util.Objects;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Contains the state of the service for an specific point in time
@@ -10,7 +11,7 @@ public class ServiceState {
     private Instant timestamp;
     private boolean healthy;
     private HealthStatus healthStatus;
-    private String reason;
+    private @Nullable String reason;
 
     /**
      * Default constructor for serialization frameworks.
@@ -103,7 +104,7 @@ public class ServiceState {
      *
      * @return the reason message, or {@code null} if not set
      */
-    public String getReason() {
+    public @Nullable String getReason() {
         return reason;
     }
 

--- a/capabilities-api/src/main/java/ai/wanaku/capabilities/sdk/api/types/discovery/package-info.java
+++ b/capabilities-api/src/main/java/ai/wanaku/capabilities/sdk/api/types/discovery/package-info.java
@@ -15,4 +15,7 @@
  *
  * @see ai.wanaku.capabilities.sdk.api.types
  */
+@NullMarked
 package ai.wanaku.capabilities.sdk.api.types.discovery;
+
+import org.jspecify.annotations.NullMarked;

--- a/capabilities-api/src/main/java/ai/wanaku/capabilities/sdk/api/types/execution/CodeExecutionError.java
+++ b/capabilities-api/src/main/java/ai/wanaku/capabilities/sdk/api/types/execution/CodeExecutionError.java
@@ -16,6 +16,7 @@
 package ai.wanaku.capabilities.sdk.api.types.execution;
 
 import java.util.Map;
+import org.jspecify.annotations.Nullable;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
@@ -46,7 +47,7 @@ public class CodeExecutionError {
      * Present when the error relates to a specific task.
      */
     @JsonProperty("taskId")
-    private String taskId;
+    private @Nullable String taskId;
 
     /**
      * The timestamp when the error occurred (Unix timestamp in milliseconds).
@@ -59,7 +60,7 @@ public class CodeExecutionError {
      * Can include field-specific validation errors, stack traces, etc.
      */
     @JsonProperty("details")
-    private Map<String, String> details;
+    private @Nullable Map<String, String> details;
 
     /**
      * Default constructor for JSON serialization.
@@ -112,7 +113,7 @@ public class CodeExecutionError {
         this.message = message;
     }
 
-    public String getTaskId() {
+    public @Nullable String getTaskId() {
         return taskId;
     }
 
@@ -128,7 +129,7 @@ public class CodeExecutionError {
         this.timestamp = timestamp;
     }
 
-    public Map<String, String> getDetails() {
+    public @Nullable Map<String, String> getDetails() {
         return details;
     }
 

--- a/capabilities-api/src/main/java/ai/wanaku/capabilities/sdk/api/types/execution/CodeExecutionEvent.java
+++ b/capabilities-api/src/main/java/ai/wanaku/capabilities/sdk/api/types/execution/CodeExecutionEvent.java
@@ -3,6 +3,7 @@ package ai.wanaku.capabilities.sdk.api.types.execution;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Events streamed via SSE to communicate execution progress and results.
@@ -36,10 +37,10 @@ public class CodeExecutionEvent {
     private String taskId;
     private long timestamp;
     private CodeExecutionStatus status;
-    private String output;
-    private String error;
-    private Integer exitCode;
-    private String message;
+    private @Nullable String output;
+    private @Nullable String error;
+    private @Nullable Integer exitCode;
+    private @Nullable String message;
     private Map<String, Object> metadata;
 
     /**
@@ -143,7 +144,7 @@ public class CodeExecutionEvent {
      *
      * @return the output content, or null if not applicable
      */
-    public String getOutput() {
+    public @Nullable String getOutput() {
         return output;
     }
 
@@ -163,7 +164,7 @@ public class CodeExecutionEvent {
      *
      * @return the error content, or null if not applicable
      */
-    public String getError() {
+    public @Nullable String getError() {
         return error;
     }
 
@@ -183,7 +184,7 @@ public class CodeExecutionEvent {
      *
      * @return the exit code, or null if not applicable
      */
-    public Integer getExitCode() {
+    public @Nullable Integer getExitCode() {
         return exitCode;
     }
 
@@ -201,7 +202,7 @@ public class CodeExecutionEvent {
      *
      * @return the message, or null if not set
      */
-    public String getMessage() {
+    public @Nullable String getMessage() {
         return message;
     }
 
@@ -228,7 +229,7 @@ public class CodeExecutionEvent {
      *
      * @param metadata a map of metadata key-value pairs
      */
-    public void setMetadata(Map<String, Object> metadata) {
+    public void setMetadata(@Nullable Map<String, Object> metadata) {
         this.metadata = metadata != null ? metadata : new HashMap<>();
     }
 

--- a/capabilities-api/src/main/java/ai/wanaku/capabilities/sdk/api/types/execution/CodeExecutionRequest.java
+++ b/capabilities-api/src/main/java/ai/wanaku/capabilities/sdk/api/types/execution/CodeExecutionRequest.java
@@ -5,6 +5,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Request payload for submitting code to be executed.
@@ -134,7 +135,7 @@ public class CodeExecutionRequest {
      *
      * @param environment a map of environment variable names to values
      */
-    public void setEnvironment(Map<String, String> environment) {
+    public void setEnvironment(@Nullable Map<String, String> environment) {
         this.environment = environment != null ? environment : new HashMap<>();
     }
 
@@ -152,7 +153,7 @@ public class CodeExecutionRequest {
      *
      * @param arguments a list of command-line arguments
      */
-    public void setArguments(List<String> arguments) {
+    public void setArguments(@Nullable List<String> arguments) {
         this.arguments = arguments != null ? arguments : new ArrayList<>();
     }
 
@@ -170,7 +171,7 @@ public class CodeExecutionRequest {
      *
      * @param metadata a map of metadata key-value pairs
      */
-    public void setMetadata(Map<String, Object> metadata) {
+    public void setMetadata(@Nullable Map<String, Object> metadata) {
         this.metadata = metadata != null ? metadata : new HashMap<>();
     }
 

--- a/capabilities-api/src/main/java/ai/wanaku/capabilities/sdk/api/types/execution/CodeExecutionTask.java
+++ b/capabilities-api/src/main/java/ai/wanaku/capabilities/sdk/api/types/execution/CodeExecutionTask.java
@@ -2,6 +2,7 @@ package ai.wanaku.capabilities.sdk.api.types.execution;
 
 import java.time.Instant;
 import java.util.Objects;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Internal representation of a code execution task.
@@ -22,9 +23,9 @@ public class CodeExecutionTask {
     private String language;
     private CodeExecutionStatus status;
     private Instant submittedAt;
-    private Instant startedAt;
-    private Instant completedAt;
-    private Integer exitCode;
+    private @Nullable Instant startedAt;
+    private @Nullable Instant completedAt;
+    private @Nullable Integer exitCode;
 
     /**
      * Default constructor for serialization frameworks.
@@ -163,7 +164,7 @@ public class CodeExecutionTask {
      *
      * @return the start timestamp, or null if not started
      */
-    public Instant getStartedAt() {
+    public @Nullable Instant getStartedAt() {
         return startedAt;
     }
 
@@ -181,7 +182,7 @@ public class CodeExecutionTask {
      *
      * @return the completion timestamp, or null if not completed
      */
-    public Instant getCompletedAt() {
+    public @Nullable Instant getCompletedAt() {
         return completedAt;
     }
 
@@ -199,7 +200,7 @@ public class CodeExecutionTask {
      *
      * @return the exit code, or null if not completed
      */
-    public Integer getExitCode() {
+    public @Nullable Integer getExitCode() {
         return exitCode;
     }
 
@@ -263,7 +264,7 @@ public class CodeExecutionTask {
      *
      * @return the duration in milliseconds, or null if not started or not completed
      */
-    public Long getExecutionDurationMs() {
+    public @Nullable Long getExecutionDurationMs() {
         if (startedAt == null || completedAt == null) {
             return null;
         }

--- a/capabilities-api/src/main/java/ai/wanaku/capabilities/sdk/api/types/execution/package-info.java
+++ b/capabilities-api/src/main/java/ai/wanaku/capabilities/sdk/api/types/execution/package-info.java
@@ -15,4 +15,7 @@
  *
  * @since 1.0.0
  */
+@NullMarked
 package ai.wanaku.capabilities.sdk.api.types.execution;
+
+import org.jspecify.annotations.NullMarked;

--- a/capabilities-api/src/main/java/ai/wanaku/capabilities/sdk/api/types/io/ProvisionAwarePayload.java
+++ b/capabilities-api/src/main/java/ai/wanaku/capabilities/sdk/api/types/io/ProvisionAwarePayload.java
@@ -1,5 +1,7 @@
 package ai.wanaku.capabilities.sdk.api.types.io;
 
+import org.jspecify.annotations.Nullable;
+
 /**
  * Interface for payloads that carry provisioning information.
  * <p>
@@ -34,7 +36,7 @@ public interface ProvisionAwarePayload<T> {
      *
      * @return the configuration data as a string, or {@code null} if no configuration is provided
      */
-    String getConfigurationData();
+    @Nullable String getConfigurationData();
 
     /**
      * Gets the secrets data associated with this payload.
@@ -45,5 +47,5 @@ public interface ProvisionAwarePayload<T> {
      *
      * @return the secrets data as a string, or {@code null} if no secrets are provided
      */
-    String getSecretsData();
+    @Nullable String getSecretsData();
 }

--- a/capabilities-api/src/main/java/ai/wanaku/capabilities/sdk/api/types/io/package-info.java
+++ b/capabilities-api/src/main/java/ai/wanaku/capabilities/sdk/api/types/io/package-info.java
@@ -15,4 +15,7 @@
  *
  * @see ai.wanaku.capabilities.sdk.api.types
  */
+@NullMarked
 package ai.wanaku.capabilities.sdk.api.types.io;
+
+import org.jspecify.annotations.NullMarked;

--- a/capabilities-api/src/main/java/ai/wanaku/capabilities/sdk/api/types/management/package-info.java
+++ b/capabilities-api/src/main/java/ai/wanaku/capabilities/sdk/api/types/management/package-info.java
@@ -1,0 +1,4 @@
+@NullMarked
+package ai.wanaku.capabilities.sdk.api.types.management;
+
+import org.jspecify.annotations.NullMarked;

--- a/capabilities-api/src/main/java/ai/wanaku/capabilities/sdk/api/types/package-info.java
+++ b/capabilities-api/src/main/java/ai/wanaku/capabilities/sdk/api/types/package-info.java
@@ -19,4 +19,7 @@
  * @see ai.wanaku.capabilities.sdk.api.types.io
  * @see ai.wanaku.capabilities.sdk.api.types.discovery
  */
+@NullMarked
 package ai.wanaku.capabilities.sdk.api.types;
+
+import org.jspecify.annotations.NullMarked;

--- a/capabilities-api/src/main/java/ai/wanaku/capabilities/sdk/api/types/providers/ServiceTarget.java
+++ b/capabilities-api/src/main/java/ai/wanaku/capabilities/sdk/api/types/providers/ServiceTarget.java
@@ -1,6 +1,7 @@
 package ai.wanaku.capabilities.sdk.api.types.providers;
 
 import java.util.Objects;
+import org.jspecify.annotations.Nullable;
 import ai.wanaku.capabilities.sdk.api.types.WanakuEntity;
 
 /**
@@ -15,10 +16,10 @@ public class ServiceTarget implements WanakuEntity<String> {
     private String host;
     private int port;
     private String serviceType;
-    private String serviceSubType;
-    private String languageName;
-    private String languageType;
-    private String languageSubType;
+    private @Nullable String serviceSubType;
+    private @Nullable String languageName;
+    private @Nullable String languageType;
+    private @Nullable String languageSubType;
 
     /**
      * Default constructor for ServiceTarget.
@@ -118,7 +119,7 @@ public class ServiceTarget implements WanakuEntity<String> {
      *
      * @return The subtype of the service, or null if not specified.
      */
-    public String getServiceSubType() {
+    public @Nullable String getServiceSubType() {
         return serviceSubType;
     }
 
@@ -136,7 +137,7 @@ public class ServiceTarget implements WanakuEntity<String> {
      *
      * @return The name of the programming language, or null if not specified.
      */
-    public String getLanguageName() {
+    public @Nullable String getLanguageName() {
         return languageName;
     }
 
@@ -154,7 +155,7 @@ public class ServiceTarget implements WanakuEntity<String> {
      *
      * @return The type of the language, or null if not specified.
      */
-    public String getLanguageType() {
+    public @Nullable String getLanguageType() {
         return languageType;
     }
 
@@ -172,7 +173,7 @@ public class ServiceTarget implements WanakuEntity<String> {
      *
      * @return The subtype of the language, or null if not specified.
      */
-    public String getLanguageSubType() {
+    public @Nullable String getLanguageSubType() {
         return languageSubType;
     }
 

--- a/capabilities-api/src/main/java/ai/wanaku/capabilities/sdk/api/types/providers/package-info.java
+++ b/capabilities-api/src/main/java/ai/wanaku/capabilities/sdk/api/types/providers/package-info.java
@@ -1,0 +1,4 @@
+@NullMarked
+package ai.wanaku.capabilities.sdk.api.types.providers;
+
+import org.jspecify.annotations.NullMarked;

--- a/capabilities-api/src/main/java/ai/wanaku/capabilities/sdk/api/util/package-info.java
+++ b/capabilities-api/src/main/java/ai/wanaku/capabilities/sdk/api/util/package-info.java
@@ -4,4 +4,7 @@
  * This package contains utility classes and constants used throughout the SDK,
  * including reserved names for special argument handling in the tool invocation protocol.
  */
+@NullMarked
 package ai.wanaku.capabilities.sdk.api.util;
+
+import org.jspecify.annotations.NullMarked;

--- a/capabilities-parent/pom.xml
+++ b/capabilities-parent/pom.xml
@@ -37,6 +37,7 @@
         <langchain4j.version>1.12.2</langchain4j.version>
         <maven.resolver.version>2.0.17</maven.resolver.version>
         <maven.resolver-provider.version>3.9.15</maven.resolver-provider.version>
+        <jspecify.version>1.0.0</jspecify.version>
         <mockito.version>5.23.0</mockito.version>
         <palantir-java-format.version>2.71.0</palantir-java-format.version>
     </properties>
@@ -84,6 +85,12 @@
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-databind</artifactId>
                 <version>${jackson-databind.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.jspecify</groupId>
+                <artifactId>jspecify</artifactId>
+                <version>${jspecify.version}</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
## Summary
- Add `org.jspecify:jspecify` 1.0.0 dependency (managed in `capabilities-parent`)
- Add `@NullMarked` to all 9 `package-info.java` files in `capabilities-api` (5 existing + 4 new)
- Add `@Nullable` annotations to 19 public API classes covering ~40 methods/fields/parameters that can be null

## Scope
This PR covers the `capabilities-api` module only. Other modules can adopt JSpecify incrementally in follow-up work.

## Test plan
- [x] Full `mvn verify` passes (all 24 modules)
- [x] Full reactor `mvn clean install -DskipTests` passes
- [ ] CI builds pass on all platforms

## Summary by Sourcery

Adopt JSpecify-based nullness metadata in the capabilities API to clarify which public API values may be null.

New Features:
- Introduce JSpecify nullness annotations across the capabilities-api public surface, including entities, records, and interfaces.

Enhancements:
- Add org.jspecify:jspecify as a managed dependency in the parent POM and as a direct dependency of the capabilities-api module.
- Mark API packages as null-marked via package-info declarations, defaulting types to non-null unless explicitly annotated.
- Annotate optional fields, method parameters, and return types with @Nullable in core API types such as execution, discovery, IO, and provider models to formalize nullability contracts.
- Relax various map/list setter methods and helper methods to explicitly accept null inputs while preserving existing defaulting behavior.
- Allow HealthStatus.fromValue to safely accept null input by documenting it via @Nullable in the signature.