### PR TITLE
chore: archive JUnit test reports as CI artifacts

### DIFF
--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -32,3 +32,14 @@ jobs:
         cache: maven
     - name: Build with Maven
       run: mvn -B --no-transfer-progress install --file pom.xml
+    - name: Generate Test Reports
+      if: always()
+      run: mvn -B --no-transfer-progress surefire-report:report-only surefire-report:failsafe-report-only -Daggregate=true
+    - name: Upload Test Reports
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: test-reports
+        path: 'target/reports/'
+        retention-days: 14
+        if-no-files-found: ignore

--- a/.github/workflows/pr-builds.yml
+++ b/.github/workflows/pr-builds.yml
@@ -36,7 +36,7 @@ jobs:
         os: [ubuntu-latest, macos-latest]
         experimental: [false]
         include:
-          - os: [ windows-latest ]
+          - os: windows-latest
             experimental: true
       fail-fast: true
 
@@ -53,3 +53,14 @@ jobs:
           cache: maven
       - name: Build with Maven
         run: mvn -B --no-transfer-progress install --file pom.xml
+      - name: Generate Test Reports
+        if: always()
+        run: mvn -B --no-transfer-progress surefire-report:report-only surefire-report:failsafe-report-only -Daggregate=true
+      - name: Upload Test Reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-reports-${{ matrix.os }}
+          path: 'target/reports/'
+          retention-days: 14
+          if-no-files-found: ignore


### PR DESCRIPTION
## Summary
- Generate aggregated surefire/failsafe test reports and upload them as CI artifacts in both main and PR build workflows
- Fix `os: [ windows-latest ]` array syntax in PR builds matrix that would produce `test-reports-Array` artifact name

## Test plan
- [ ] Verify main build produces a `test-reports` artifact with aggregated HTML report
- [ ] Verify PR build produces `test-reports-<os>` artifacts for each matrix OS
- [ ] Verify reports are generated even when tests fail (`if: always()`)

## Summary by Sourcery

Archive aggregated Maven test reports as artifacts in both main and PR CI workflows.

CI:
- Upload aggregated surefire/failsafe HTML test reports as artifacts in the main build workflow.
- Upload per-OS aggregated test report artifacts in the PR builds matrix, ensuring reports are generated even on test failures.
- Fix PR build matrix configuration so the Windows job uses a scalar OS value instead of an array, producing correct artifact names.