### PR TITLE
chore: release preparation for 0.1.1

### DIFF
--- a/capabilities-api/src/main/java/ai/wanaku/capabilities/sdk/api/types/execution/CodeExecutionEvent.java
+++ b/capabilities-api/src/main/java/ai/wanaku/capabilities/sdk/api/types/execution/CodeExecutionEvent.java
@@ -30,7 +30,7 @@ import org.jspecify.annotations.Nullable;
  * event.setTimestamp(System.currentTimeMillis());
  * }</pre>
  *
- * @since 1.0.0
+ * @since 0.1.1
  */
 public class CodeExecutionEvent {
     private CodeExecutionEventType eventType;

--- a/capabilities-api/src/main/java/ai/wanaku/capabilities/sdk/api/types/execution/CodeExecutionEventType.java
+++ b/capabilities-api/src/main/java/ai/wanaku/capabilities/sdk/api/types/execution/CodeExecutionEventType.java
@@ -6,7 +6,7 @@ package ai.wanaku.capabilities.sdk.api.types.execution;
  * These event types are used in Server-Sent Events (SSE) to communicate
  * the progress and results of code execution to clients.
  *
- * @since 1.0.0
+ * @since 0.1.1
  */
 public enum CodeExecutionEventType {
     /**

--- a/capabilities-api/src/main/java/ai/wanaku/capabilities/sdk/api/types/execution/CodeExecutionRequest.java
+++ b/capabilities-api/src/main/java/ai/wanaku/capabilities/sdk/api/types/execution/CodeExecutionRequest.java
@@ -22,7 +22,7 @@ import org.jspecify.annotations.Nullable;
  * request.setEnvironment(Map.of("ENV_VAR", "value"));
  * }</pre>
  *
- * @since 1.0.0
+ * @since 0.1.1
  */
 public class CodeExecutionRequest {
     /**

--- a/capabilities-api/src/main/java/ai/wanaku/capabilities/sdk/api/types/execution/CodeExecutionResponse.java
+++ b/capabilities-api/src/main/java/ai/wanaku/capabilities/sdk/api/types/execution/CodeExecutionResponse.java
@@ -23,7 +23,7 @@ import java.util.Objects;
  * @param streamUrl the full URL to the SSE stream endpoint
  * @param status the initial status of the task (typically PENDING)
  * @param submittedAt the timestamp (epoch milliseconds) when the task was submitted
- * @since 1.0.0
+ * @since 0.1.1
  */
 public record CodeExecutionResponse(String taskId, String streamUrl, CodeExecutionStatus status, long submittedAt) {
 

--- a/capabilities-api/src/main/java/ai/wanaku/capabilities/sdk/api/types/execution/CodeExecutionStatus.java
+++ b/capabilities-api/src/main/java/ai/wanaku/capabilities/sdk/api/types/execution/CodeExecutionStatus.java
@@ -11,7 +11,7 @@ package ai.wanaku.capabilities.sdk.api.types.execution;
  * RUNNING → CANCELLED
  * </pre>
  *
- * @since 1.0.0
+ * @since 0.1.1
  */
 public enum CodeExecutionStatus {
     /**

--- a/capabilities-api/src/main/java/ai/wanaku/capabilities/sdk/api/types/execution/CodeExecutionTask.java
+++ b/capabilities-api/src/main/java/ai/wanaku/capabilities/sdk/api/types/execution/CodeExecutionTask.java
@@ -14,7 +14,7 @@ import org.jspecify.annotations.Nullable;
  * This class combines the original request with runtime state information such as
  * execution timestamps and status.
  *
- * @since 1.0.0
+ * @since 0.1.1
  */
 public class CodeExecutionTask {
     private String taskId;

--- a/capabilities-api/src/main/java/ai/wanaku/capabilities/sdk/api/types/execution/package-info.java
+++ b/capabilities-api/src/main/java/ai/wanaku/capabilities/sdk/api/types/execution/package-info.java
@@ -13,7 +13,7 @@
  *   <li>{@link ai.wanaku.capabilities.sdk.api.types.execution.CodeExecutionEventType} - Event type enumeration</li>
  * </ul>
  *
- * @since 1.0.0
+ * @since 0.1.1
  */
 @NullMarked
 package ai.wanaku.capabilities.sdk.api.types.execution;

--- a/capabilities-archetypes/capabilities-archetypes-java-tool/src/main/resources/archetype-resources/pom.xml
+++ b/capabilities-archetypes/capabilities-archetypes-java-tool/src/main/resources/archetype-resources/pom.xml
@@ -10,8 +10,8 @@
         <maven.compiler.target>21</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <slf4j.version>2.0.17</slf4j.version>
-        <log4j.version>2.25.3</log4j.version>
+        <slf4j.version>2.0.18</slf4j.version>
+        <log4j.version>2.26.0</log4j.version>
         <picocli.version>4.7.6</picocli.version>
         <maven-assembly-plugin.version>3.7.1</maven-assembly-plugin.version>
         <wanaku.sdk.version>${wanaku-sdk-version}</wanaku.sdk.version>

--- a/capabilities-archetypes/capabilities-archetypes-java-tool/src/test/resources/projects/basic/verify.groovy
+++ b/capabilities-archetypes/capabilities-archetypes-java-tool/src/test/resources/projects/basic/verify.groovy
@@ -46,8 +46,8 @@ assert pomContent.contains("capabilities-config-provider-api") : "pom.xml does n
 assert pomContent.contains("capabilities-config-provider-file") : "pom.xml does not include capabilities-config-provider-file dependency"
 
 // Verify correct dependency versions
-assert pomContent.contains("<slf4j.version>2.0.17</slf4j.version>") : "pom.xml has outdated slf4j version"
-assert pomContent.contains("<log4j.version>2.25.3</log4j.version>") : "pom.xml has outdated log4j version"
+assert pomContent.contains("<slf4j.version>2.0.18</slf4j.version>") : "pom.xml has outdated slf4j version"
+assert pomContent.contains("<log4j.version>2.26.0</log4j.version>") : "pom.xml has outdated log4j version"
 
 // Check source directory structure
 def srcMainJava = new File(projectDir, "src/main/java/ai/wanaku/test")

--- a/capabilities-discovery/src/main/java/ai/wanaku/capabilities/sdk/discovery/ZeroDepRegistrationManager.java
+++ b/capabilities-discovery/src/main/java/ai/wanaku/capabilities/sdk/discovery/ZeroDepRegistrationManager.java
@@ -243,7 +243,7 @@ public class ZeroDepRegistrationManager implements RegistrationManager {
                             e);
                 } else {
                     LOG.warn(
-                            "Unable to run callback {}} due to {}",
+                            "Unable to run callback {} due to {}",
                             callback.getClass().getName(),
                             e.getMessage());
                 }

--- a/docs/release.md
+++ b/docs/release.md
@@ -3,8 +3,8 @@
 Export the variables:
 
 ```shell
-export CURRENT_DEVELOPMENT_VERSION=0.1.0
-export NEXT_DEVELOPMENT_VERSION=0.1.1
+export CURRENT_DEVELOPMENT_VERSION=0.1.1
+export NEXT_DEVELOPMENT_VERSION=0.2.0
 ```
 
 Trigger the release automation: 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -81,7 +81,7 @@ Add the following dependency to your project:
 <dependency>
     <groupId>ai.wanaku.sdk</groupId>
     <artifactId>capabilities-runtime-camel-plugin</artifactId>
-    <version>0.1.0-SNAPSHOT</version>
+    <version>${WANAKU_VERSION}</version>
 </dependency>
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
     <scm>
         <connection>scm:git:https://github.com/wanaku-ai/wanaku-capabilities-java-sdk.git</connection>
         <developerConnection>scm:git:https://github.com/wanaku-ai/wanaku-capabilities-java-sdk.git</developerConnection>
-        <url>https://github.com/wanaku-ai/wanaku</url>
+        <url>https://github.com/wanaku-ai/wanaku-capabilities-java-sdk</url>
         <tag>HEAD</tag>
     </scm>
 


### PR DESCRIPTION
## Summary

Pre-release verification and fixes for the 0.1.1 release.

- Fix SCM `<url>` in root pom.xml pointing to `wanaku-ai/wanaku` instead of `wanaku-ai/wanaku-capabilities-java-sdk`
- Fix hardcoded `0.1.0-SNAPSHOT` version in `docs/usage.md`, replaced with `${WANAKU_VERSION}` placeholder
- Update `docs/release.md` example variables to current release cycle (`0.1.1` → `0.2.0`)
- Fix log format typo in `ZeroDepRegistrationManager` (`{}}` → `{}`)
- Correct `@since 1.0.0` to `@since 0.1.1` on 7 execution type classes
- Align archetype template SLF4J (`2.0.17` → `2.0.18`) and Log4j (`2.25.3` → `2.26.0`) versions with SDK parent

## Test plan

- [x] `mvn verify` passes (including archetype integration test)

## Summary by Sourcery

Prepare codebase and documentation for the 0.1.1 release cycle.

Bug Fixes:
- Correct the SCM URL in the root Maven POM to point to the capabilities Java SDK repository.
- Fix a log message format typo in ZeroDepRegistrationManager warnings.

Enhancements:
- Align archetype SLF4J and Log4j dependency versions with the SDK parent versions.
- Update @since tags on code execution API types to reflect introduction in version 0.1.1.

Documentation:
- Update release documentation to use the current and next development versions for this release cycle.
- Replace hardcoded dependency version in usage documentation with a WANAKU_VERSION placeholder.

Tests:
- Adjust archetype verification test expectations to the updated SLF4J and Log4j versions.