### PR TITLE
chore: warm javadoc.io caches after release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,6 +56,11 @@ jobs:
           JRELEASER_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           JRELEASER_PROJECT_VERSION: ${{ github.event.inputs.currentDevelopmentVersion }}
 
+      # Warm up javadoc.io caches
+
+      - name: Warm javadoc.io caches
+        run: bash docs/javadoc-warm.sh
+
       # Persist logs
 
       - name: JReleaser release output

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,6 +59,7 @@ jobs:
       # Warm up javadoc.io caches
 
       - name: Warm javadoc.io caches
+        continue-on-error: true
         run: bash docs/javadoc-warm.sh
 
       # Persist logs

--- a/docs/javadoc-warm.sh
+++ b/docs/javadoc-warm.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+# Warms up javadoc.io caches for all publishable modules in this project.
+# Usage: ./docs/javadoc-warm.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+find "$PROJECT_ROOT" -name "pom.xml" \
+    -not -path "*/target/*" \
+    -not -path "*/archetype-resources/*" \
+    -not -path "*/tests/*" \
+    | sort | while read -r pom; do
+
+    read -r gid aid pkg < <(python3 - "$pom" <<'PYEOF'
+import xml.etree.ElementTree as ET, sys
+ns = '{http://maven.apache.org/POM/4.0.0}'
+tree = ET.parse(sys.argv[1])
+root = tree.getroot()
+
+aid_el = root.find(ns + 'artifactId')
+aid = aid_el.text if aid_el is not None else ''
+
+pkg_el = root.find(ns + 'packaging')
+pkg = pkg_el.text if pkg_el is not None else 'jar'
+
+gid_el = root.find(ns + 'groupId')
+if gid_el is None:
+    parent = root.find(ns + 'parent')
+    if parent is not None:
+        gid_el = parent.find(ns + 'groupId')
+gid = gid_el.text if gid_el is not None else ''
+
+print(f'{gid} {aid} {pkg}')
+PYEOF
+    )
+
+    if [[ "$pkg" == "pom" || "$pkg" == "maven-archetype" ]]; then
+        continue
+    fi
+
+    url="https://javadoc.io/doc/${gid}/${aid}"
+    echo "Warming: ${gid}:${aid} -> ${url}"
+    curl -sf -o /dev/null "$url" || echo "  WARNING: failed for ${aid}"
+done
+
+echo "Done."


### PR DESCRIPTION
## Summary
- Add `docs/javadoc-warm.sh` script that dynamically discovers all jar-packaged modules and curls their javadoc.io URLs to warm the cache
- Run the script in the release workflow after the JReleaser step

## Test plan
- [x] Verified the script discovers all 16 publishable modules
- [x] Verified archetype templates and test poms are excluded

## Summary by Sourcery

Warm javadoc.io caches for all publishable modules as part of the release workflow.

Enhancements:
- Add a javadoc-warming script that discovers publishable Maven modules and triggers their javadoc.io pages to prime caches.

CI:
- Invoke the javadoc-warming script in the GitHub Actions release workflow after the JReleaser step.