### PR TITLE
chore: add missing Javadoc to undocumented public classes

### DIFF
--- a/capabilities-api/src/main/java/ai/wanaku/capabilities/sdk/api/types/discovery/ServiceState.java
+++ b/capabilities-api/src/main/java/ai/wanaku/capabilities/sdk/api/types/discovery/ServiceState.java
@@ -5,7 +5,10 @@ import java.util.Objects;
 import org.jspecify.annotations.Nullable;
 
 /**
- * Contains the state of the service for an specific point in time
+ * Represents a point-in-time snapshot of a service's health. Each state carries a timestamp,
+ * a boolean healthy flag, a detailed {@link HealthStatus}, and an optional reason message.
+ * Use the static factory methods ({@code newHealthy()}, {@code newUnhealthy(String)}, etc.)
+ * to create instances for common lifecycle transitions.
  */
 public class ServiceState {
     private Instant timestamp;

--- a/capabilities-runtimes/capabilities-runtimes-camel/capabilities-runtimes-camel-common/src/main/java/ai/wanaku/capabilities/sdk/runtime/camel/downloader/DownloaderFactory.java
+++ b/capabilities-runtimes/capabilities-runtimes-camel/capabilities-runtimes-camel-common/src/main/java/ai/wanaku/capabilities/sdk/runtime/camel/downloader/DownloaderFactory.java
@@ -6,6 +6,11 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import ai.wanaku.capabilities.sdk.services.ServicesHttpClient;
 
+/**
+ * Factory that selects the appropriate {@link Downloader} for a given URI scheme.
+ * Supported schemes are {@code datastore://} and {@code file://}. Downloader instances
+ * are created lazily and reused for subsequent requests.
+ */
 public class DownloaderFactory {
     private static final Logger LOG = LoggerFactory.getLogger(DownloaderFactory.class);
 

--- a/capabilities-runtimes/capabilities-runtimes-camel/capabilities-runtimes-camel-common/src/main/java/ai/wanaku/capabilities/sdk/runtime/camel/downloader/ResourceDownloaderCallback.java
+++ b/capabilities-runtimes/capabilities-runtimes-camel/capabilities-runtimes-camel-common/src/main/java/ai/wanaku/capabilities/sdk/runtime/camel/downloader/ResourceDownloaderCallback.java
@@ -13,6 +13,11 @@ import ai.wanaku.capabilities.sdk.api.discovery.RegistrationManager;
 import ai.wanaku.capabilities.sdk.api.types.providers.ServiceTarget;
 import ai.wanaku.capabilities.sdk.common.exceptions.WanakuWebException;
 
+/**
+ * A {@link DiscoveryCallback} that downloads a set of resources after successful service registration.
+ * Downloads are executed with configurable retry logic and the caller can block on
+ * {@link #waitForDownloads()} until all resources have been fetched.
+ */
 public class ResourceDownloaderCallback implements DiscoveryCallback {
     private static final Logger LOG = LoggerFactory.getLogger(ResourceDownloaderCallback.class);
 

--- a/capabilities-runtimes/capabilities-runtimes-camel/capabilities-runtimes-camel-common/src/main/java/ai/wanaku/capabilities/sdk/runtime/camel/downloader/ResourceType.java
+++ b/capabilities-runtimes/capabilities-runtimes-camel/capabilities-runtimes-camel-common/src/main/java/ai/wanaku/capabilities/sdk/runtime/camel/downloader/ResourceType.java
@@ -1,8 +1,15 @@
 package ai.wanaku.capabilities.sdk.runtime.camel.downloader;
 
+/**
+ * Identifies the type of downloadable resource within a service catalog.
+ */
 public enum ResourceType {
+    /** Camel route definitions. */
     ROUTES_REF,
+    /** MCP rule files that govern tool and resource behaviour. */
     RULES_REF,
+    /** Maven dependency coordinates required at runtime. */
     DEPENDENCY_REF,
+    /** Configuration properties files. */
     PROPERTIES_REF,
 }

--- a/capabilities-runtimes/capabilities-runtimes-camel/capabilities-runtimes-camel-common/src/main/java/ai/wanaku/capabilities/sdk/runtime/camel/downloader/ServiceCatalogDownloaderCallback.java
+++ b/capabilities-runtimes/capabilities-runtimes-camel/capabilities-runtimes-camel-common/src/main/java/ai/wanaku/capabilities/sdk/runtime/camel/downloader/ServiceCatalogDownloaderCallback.java
@@ -12,6 +12,11 @@ import ai.wanaku.capabilities.sdk.api.types.DataStore;
 import ai.wanaku.capabilities.sdk.api.types.WanakuResponse;
 import ai.wanaku.capabilities.sdk.api.types.providers.ServiceTarget;
 
+/**
+ * A {@link DiscoveryCallback} that downloads and extracts a service catalog after
+ * successful registration. The catalog is fetched via the services HTTP client and
+ * extracted into the local data directory using {@link ServiceCatalogExtractor}.
+ */
 public class ServiceCatalogDownloaderCallback implements DiscoveryCallback {
     private static final Logger LOG = LoggerFactory.getLogger(ServiceCatalogDownloaderCallback.class);
 

--- a/capabilities-runtimes/capabilities-runtimes-camel/capabilities-runtimes-camel-common/src/main/java/ai/wanaku/capabilities/sdk/runtime/camel/grpc/CamelHealthProbe.java
+++ b/capabilities-runtimes/capabilities-runtimes-camel/capabilities-runtimes-camel-common/src/main/java/ai/wanaku/capabilities/sdk/runtime/camel/grpc/CamelHealthProbe.java
@@ -11,6 +11,10 @@ import ai.wanaku.core.exchange.v1.HealthProbeReply;
 import ai.wanaku.core.exchange.v1.HealthProbeRequest;
 import ai.wanaku.core.exchange.v1.RuntimeStatus;
 
+/**
+ * gRPC health-probe service that reports the runtime status of the Camel context.
+ * Maps Camel {@link ServiceStatus} values to the Wanaku {@link RuntimeStatus} protocol.
+ */
 public class CamelHealthProbe extends HealthProbeGrpc.HealthProbeImplBase {
     private static final Logger LOG = LoggerFactory.getLogger(CamelHealthProbe.class);
 

--- a/capabilities-runtimes/capabilities-runtimes-camel/capabilities-runtimes-camel-common/src/main/java/ai/wanaku/capabilities/sdk/runtime/camel/grpc/CamelResource.java
+++ b/capabilities-runtimes/capabilities-runtimes-camel/capabilities-runtimes-camel-common/src/main/java/ai/wanaku/capabilities/sdk/runtime/camel/grpc/CamelResource.java
@@ -18,6 +18,11 @@ import ai.wanaku.core.exchange.v1.ResourceAcquirerGrpc;
 import ai.wanaku.core.exchange.v1.ResourceReply;
 import ai.wanaku.core.exchange.v1.ResourceRequest;
 
+/**
+ * gRPC service that acquires MCP resources by consuming from Camel routes.
+ * Resolves the requested resource URI to a route definition and reads from
+ * the corresponding Camel endpoint.
+ */
 public class CamelResource extends ResourceAcquirerGrpc.ResourceAcquirerImplBase {
     private static final Logger LOG = LoggerFactory.getLogger(CamelResource.class);
 

--- a/capabilities-runtimes/capabilities-runtimes-camel/capabilities-runtimes-camel-common/src/main/java/ai/wanaku/capabilities/sdk/runtime/camel/grpc/CamelTool.java
+++ b/capabilities-runtimes/capabilities-runtimes-camel/capabilities-runtimes-camel-common/src/main/java/ai/wanaku/capabilities/sdk/runtime/camel/grpc/CamelTool.java
@@ -20,6 +20,11 @@ import ai.wanaku.core.exchange.v1.ToolInvokeReply;
 import ai.wanaku.core.exchange.v1.ToolInvokeRequest;
 import ai.wanaku.core.exchange.v1.ToolInvokerGrpc;
 
+/**
+ * gRPC service that invokes MCP tools by producing to Camel routes.
+ * Resolves the requested tool URI to a route definition, maps request
+ * arguments to Camel headers, and sends the body to the endpoint.
+ */
 public class CamelTool extends ToolInvokerGrpc.ToolInvokerImplBase {
     private static final Logger LOG = LoggerFactory.getLogger(CamelTool.class);
 

--- a/capabilities-runtimes/capabilities-runtimes-camel/capabilities-runtimes-camel-common/src/main/java/ai/wanaku/capabilities/sdk/runtime/camel/grpc/WanakuRegistrationInfo.java
+++ b/capabilities-runtimes/capabilities-runtimes-camel/capabilities-runtimes-camel-common/src/main/java/ai/wanaku/capabilities/sdk/runtime/camel/grpc/WanakuRegistrationInfo.java
@@ -4,4 +4,12 @@ import org.apache.camel.CamelContext;
 import ai.wanaku.capabilities.sdk.api.types.providers.ServiceTarget;
 import ai.wanaku.capabilities.sdk.runtime.camel.model.McpSpec;
 
+/**
+ * Holds the resolved Camel context, MCP specification, and service target
+ * that together define a registered capability service instance.
+ *
+ * @param camelContext the running Camel context
+ * @param mcpSpec the parsed MCP tool and resource definitions
+ * @param serviceTarget the service endpoint registered with the router
+ */
 public record WanakuRegistrationInfo(CamelContext camelContext, McpSpec mcpSpec, ServiceTarget serviceTarget) {}

--- a/capabilities-runtimes/capabilities-runtimes-camel/capabilities-runtimes-camel-common/src/main/java/ai/wanaku/capabilities/sdk/runtime/camel/grpc/WanakuRegistrationInfoResolver.java
+++ b/capabilities-runtimes/capabilities-runtimes-camel/capabilities-runtimes-camel-common/src/main/java/ai/wanaku/capabilities/sdk/runtime/camel/grpc/WanakuRegistrationInfoResolver.java
@@ -4,6 +4,11 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import io.grpc.Status;
 
+/**
+ * Lazily resolves a {@link WanakuRegistrationInfo} from a {@link Future}.
+ * Returns a cached instance after the first successful resolution. Throws a
+ * gRPC {@code FAILED_PRECONDITION} status if the context is not yet available.
+ */
 public class WanakuRegistrationInfoResolver {
     private final Future<WanakuRegistrationInfo> registrationInfoFuture;
     private volatile WanakuRegistrationInfo registrationInfo;


### PR DESCRIPTION
## Summary

- Added class-level Javadoc to 9 public classes and 1 enum that were missing documentation in the `capabilities-runtimes-camel-common` module
- Improved the `ServiceState` class-level Javadoc from a single sentence to a proper description covering lifecycle factory methods
- Added Javadoc to all `ResourceType` enum values

## Files changed

**Downloader subsystem:**
- `DownloaderFactory` — documents URI scheme routing (`datastore://`, `file://`)
- `ResourceDownloaderCallback` — documents callback lifecycle and retry behaviour
- `ServiceCatalogDownloaderCallback` — documents catalog download and extraction flow
- `ResourceType` — documents each enum value

**gRPC services:**
- `CamelHealthProbe` — documents Camel-to-Wanaku status mapping
- `CamelResource` — documents resource acquisition via Camel consumer
- `CamelTool` — documents tool invocation via Camel producer
- `WanakuRegistrationInfo` — documents record components
- `WanakuRegistrationInfoResolver` — documents lazy resolution pattern

**API types:**
- `ServiceState` — expanded from one-liner to full class description

## Test plan

- [x] `mvn verify` passes

## Summary by Sourcery

Document public API and Camel gRPC integration classes with class-level Javadoc and clarify service health state semantics.

Enhancements:
- Clarify the semantics of the ServiceState type by expanding its class-level description to cover health details and factory usage.

Documentation:
- Add class-level Javadoc to Camel downloader, gRPC service, and registration helper classes to describe their responsibilities and lifecycles.
- Document all ResourceType enum values and their roles within the service catalog.
- Describe the WanakuRegistrationInfo record components to explain what constitutes a registered service instance.