### PR TITLE
chore: pass release version to javadoc warm script

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,7 +60,7 @@ jobs:
 
       - name: Warm javadoc.io caches
         continue-on-error: true
-        run: bash docs/javadoc-warm.sh
+        run: bash docs/javadoc-warm.sh ${{ github.event.inputs.currentDevelopmentVersion }}
 
       # Persist logs
 

--- a/docs/javadoc-warm.sh
+++ b/docs/javadoc-warm.sh
@@ -1,8 +1,10 @@
 #!/bin/bash
 # Warms up javadoc.io caches for all publishable modules in this project.
-# Usage: ./docs/javadoc-warm.sh
+# Usage: ./docs/javadoc-warm.sh <version>
 
 set -euo pipefail
+
+VERSION="${1:?Usage: $0 <version>}"
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
@@ -40,8 +42,8 @@ PYEOF
         continue
     fi
 
-    url="https://javadoc.io/doc/${gid}/${aid}"
-    echo "Warming: ${gid}:${aid} -> ${url}"
+    url="https://javadoc.io/doc/${gid}/${aid}/${VERSION}"
+    echo "Warming: ${gid}:${aid}:${VERSION} -> ${url}"
     curl -sf -o /dev/null "$url" || echo "  WARNING: failed for ${aid}"
 done
 


### PR DESCRIPTION
## Summary
- Pass the released version to `docs/javadoc-warm.sh` so it warms the correct versioned javadoc.io URL (`/doc/{gid}/{aid}/{version}`) instead of the unversioned one
- Make the script require a version argument

## Test plan
- [ ] Verify the script runs locally: `bash docs/javadoc-warm.sh <version>`
- [ ] Confirm the release workflow passes the version input to the script

## Summary by Sourcery

Require a release version argument for the javadoc warm-up script and ensure the release workflow passes this version so the correct versioned javadoc.io URLs are warmed.

Enhancements:
- Update javadoc warm-up script to target versioned javadoc.io URLs using an explicit version parameter.

CI:
- Modify the release GitHub Actions workflow to pass the current development version to the javadoc warm-up script.