### PR TITLE
chore: add markdownlint CI and fix existing violations

### DIFF
--- a/.github/workflows/markdown-lint.yml
+++ b/.github/workflows/markdown-lint.yml
@@ -1,0 +1,17 @@
+name: Markdown Lint
+
+on:
+  pull_request:
+    branches:
+      - "main"
+    paths:
+      - "docs/**/*.md"
+      - "*.md"
+      - ".markdownlint-cli2.yaml"
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: DavidAnson/markdownlint-cli2-action@v19

--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -1,0 +1,19 @@
+config:
+  MD004:
+    style: "dash"
+  MD013: false
+  MD024:
+    siblings_only: true
+  MD025: false
+  MD033: false
+  MD036: false
+  MD060: false
+
+globs:
+  - "docs/**/*.md"
+  - "*.md"
+
+ignores:
+  - ".oss-ai-helper-rules/**"
+  - "CLAUDE.md"
+  - "target/**"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Wanaku Capabilities Java SDK
 
-This project is a plain-Java SDK designed to facilitate the creation of new capabilities for the [Wanaku MCP Router](http://wanaku.ai). 
+This project is a plain-Java SDK designed to facilitate the creation of new capabilities for the [Wanaku MCP Router](http://wanaku.ai).
 These new capabilities serve to augment Wanaku by enabling it to handle various tool types, extending its functionality and versatility.
 
 For more information about the main Wanaku project, please visit the [Wanaku GitHub repository](http://github.com/wanaku-ai/wanaku).

--- a/docs/client-registration-flow.md
+++ b/docs/client-registration-flow.md
@@ -17,7 +17,7 @@ The Wanaku registration system enables capability services (tools, resources, co
 
 ## Registration Flow Diagram
 
-```
+```text
 ┌─────────────────────────────────────────────────────────────────────────────┐
 │                         CLIENT REGISTRATION FLOW                            │
 └─────────────────────────────────────────────────────────────────────────────┘
@@ -144,7 +144,7 @@ All endpoints use the base path: `/api/v1/management/discovery`
 
 All requests must include the `Authorization` header with a Bearer token:
 
-```
+```text
 Authorization: Bearer {access_token}
 ```
 
@@ -330,6 +330,7 @@ registrationManager.start();
 ```
 
 This initiates:
+
 1. Initial registration attempt (with retries)
 2. Periodic heartbeat loop
 3. Automatic ID persistence
@@ -355,7 +356,7 @@ registrationManager.deregister();
 
 ## State Machine
 
-```
+```text
                                   ┌─────────────┐
                                   │             │
                         ┌────────►│  REGISTERED │◄────────┐
@@ -407,6 +408,7 @@ Handle HTTP errors appropriately:
 ### Token Expiration
 
 The SDK automatically handles token refresh:
+
 - Tokens are refreshed 30 seconds before expiration
 - Uses refresh token if available
 - Falls back to client credentials grant
@@ -415,15 +417,17 @@ The SDK automatically handles token refresh:
 
 Service IDs are persisted locally to survive restarts:
 
-```
+```text
 {dataDir}/{serviceName}.wanaku.dat
 ```
 
 File format (binary):
+
 - File header (magic bytes + version)
 - Service entry: 36-byte UUID + 4 bytes padding
 
 This allows:
+
 - Service to maintain same ID across restarts
 - Router to recognize returning services
 - Continuous activity tracking

--- a/docs/registration-data-files.md
+++ b/docs/registration-data-files.md
@@ -5,6 +5,7 @@ This document explains how the registration process uses data files to persist t
 ## Overview
 
 When a capability service registers with the Wanaku Router, it receives a unique UUID. This ID must be persisted locally to:
+
 - Maintain identity across service restarts
 - Avoid duplicate registrations
 - Enable proper heartbeat and state update operations
@@ -14,12 +15,14 @@ When a capability service registers with the Wanaku Router, it receives a unique
 ### File Location and Naming
 
 Data files follow this naming convention:
-```
+
+```text
 {dataDir}/{serviceName}.wanaku.dat
 ```
 
 For example, a tool invoker service named "my-tool" with data directory `/var/wanaku` stores its ID at:
-```
+
+```text
 /var/wanaku/my-tool.wanaku.dat
 ```
 
@@ -27,7 +30,7 @@ For example, a tool invoker service named "my-tool" with data directory `/var/wa
 
 The data file uses a fixed-size binary format totaling 64 bytes:
 
-```
+```text
 +------------------------+
 |    FileHeader (24B)    |
 +------------------------+
@@ -84,6 +87,7 @@ if (instanceDataManager.dataFileExists()) {
 ```
 
 Key classes:
+
 - `InstanceDataManager`: Central persistence coordinator
 - `InstanceDataReader`: Binary file reader
 
@@ -129,7 +133,7 @@ public void writeEntry(ServiceTarget target) {
 
 ## Data Flow Diagram
 
-```
+```text
 ┌─────────────────────────────────────────────────────────────┐
 │                   Service Startup                           │
 └──────────────────────────┬──────────────────────────────────┘
@@ -182,15 +186,19 @@ public void writeEntry(ServiceTarget target) {
 ## Design Considerations
 
 ### Idempotency
+
 The `writeEntry()` method checks if the file already exists before writing. This prevents accidental overwrites and ensures the original ID persists across the service lifetime.
 
 ### Binary Format
+
 Using a fixed-size binary format provides:
+
 - Efficient I/O with predictable buffer sizes
 - Fast reads without parsing overhead
 - Clear versioning for future format changes
 
 ### Thread Safety
+
 - File operations use `FileChannel` for atomic reads/writes
 - `InstanceDataReader` and `InstanceDataWriter` implement `AutoCloseable` for proper resource management
 

--- a/docs/release.md
+++ b/docs/release.md
@@ -7,7 +7,7 @@ export CURRENT_DEVELOPMENT_VERSION=0.1.1
 export NEXT_DEVELOPMENT_VERSION=0.2.0
 ```
 
-Trigger the release automation: 
+Trigger the release automation:
 
 ```shell
 gh workflow run release -f currentDevelopmentVersion=${CURRENT_DEVELOPMENT_VERSION} -f nextDevelopmentVersion=${NEXT_DEVELOPMENT_VERSION}

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -19,14 +19,14 @@ mvn -B archetype:generate -DarchetypeGroupId=ai.wanaku.sdk \
 
 **Explanation of Parameters:**
 
-*   `-DarchetypeGroupId`: The groupId of the archetype (always `ai.wanaku.sdk`).
-*   `-DarchetypeArtifactId`: The artifactId of the archetype (always `capabilities-archetypes-java-tool`).
-*   `-DarchetypeVersion`: The version of the archetype. Use the current version of the Wanaku SDK, typically passed as `${WANAKU_VERSION}`.
-*   `-DgroupId`: Your project's group ID (e.g., `com.mycompany`).
-*   `-Dpackage`: Your project's base package (e.g., `com.mycompany.mytool`).
-*   `-DartifactId`: Your project's artifact ID (e.g., `my-awesome-tool`).
-*   `-Dname`: A human-readable name for your capability (e.g., `My Awesome Tool`).
-*   `-Dwanaku-sdk-version`: The version of the Wanaku SDK to be used in the generated project. This should match `${WANAKU_VERSION}`.
+- `-DarchetypeGroupId`: The groupId of the archetype (always `ai.wanaku.sdk`).
+- `-DarchetypeArtifactId`: The artifactId of the archetype (always `capabilities-archetypes-java-tool`).
+- `-DarchetypeVersion`: The version of the archetype. Use the current version of the Wanaku SDK, typically passed as `${WANAKU_VERSION}`.
+- `-DgroupId`: Your project's group ID (e.g., `com.mycompany`).
+- `-Dpackage`: Your project's base package (e.g., `com.mycompany.mytool`).
+- `-DartifactId`: Your project's artifact ID (e.g., `my-awesome-tool`).
+- `-Dname`: A human-readable name for your capability (e.g., `My Awesome Tool`).
+- `-Dwanaku-sdk-version`: The version of the Wanaku SDK to be used in the generated project. This should match `${WANAKU_VERSION}`.
 
 ## Modifying the Generated Tool Class
 
@@ -65,7 +65,7 @@ public class AppTool extends ToolInvokerGrpc.ToolInvokerImplBase {
 }
 ```
 
-Replace the `// TODO: Implement your tool's logic here` comment with your specific business logic. 
+Replace the `// TODO: Implement your tool's logic here` comment with your specific business logic.
 
 The `ToolInvokeRequest` object provides access to various information and services relevant to the tool's execution request.
 
@@ -177,6 +177,7 @@ tools:
 ```
 
 The `ROUTES_RULES` variable supports:
+
 - File paths: `file:///path/to/rules.yaml`
 - Datastore references: `datastore://rules.yaml`
 
@@ -194,6 +195,7 @@ java -jar target/my-app.jar
 ```
 
 Once running, the plugin:
+
 1. Registers with the Wanaku router
 2. Loads the MCP tool definitions from the rules file
 3. Starts a gRPC server exposing your routes as callable tools
@@ -201,7 +203,7 @@ Once running, the plugin:
 ### Example
 
 For a complete working example, see the [Cat Facts Example](https://github.com/wanaku-ai/wanaku-demos/tree/main/06-camel-integration-capability-existing-route/sample-routes/camel-core-examples/cat-facts-example) in the Wanaku Demos repository.
-=======
+
 ## Accessing Request Data
 
 The `ToolInvokeRequest` provides several methods to access invocation data:
@@ -276,7 +278,6 @@ String prefix = ReservedArgumentNames.METADATA_PREFIX;  // "wanaku_meta_"
 | `BODY` | `wanaku_body` | Argument containing request body content |
 | `METADATA_PREFIX` | `wanaku_meta_` | Prefix for arguments converted to headers |
 
-
-# Learn More
+## Learn More
 
 - **[Client Registration Flow](client-registration-flow.md)** - Client Registration Flow


### PR DESCRIPTION
## Summary

- Add `markdownlint-cli2` configuration (`.markdownlint-cli2.yaml`) with pragmatic rule settings: disable line-length, inline HTML, table-column-style, and emphasis-as-heading rules; set dash list style
- Add GitHub Actions workflow (`.github/workflows/markdown-lint.yml`) that runs on PRs to `main` when documentation files change
- Fix all existing markdown violations across docs and README so the CI gate passes from day one

## Test plan

- [ ] Verify `npx markdownlint-cli2` exits with 0 locally
- [ ] Verify the new workflow triggers on a PR that modifies docs
- [ ] Spot-check rendered markdown for formatting regressions

## Summary by Sourcery

Add markdown linting to the repository and clean up existing markdown files to comply with the new rules.

Enhancements:
- Add markdownlint-cli2 configuration to standardize markdown style across docs and top-level markdown files.
- Normalize markdown formatting in documentation and README (lists, code fences, headings, spacing, and trailing whitespace).

CI:
- Introduce a GitHub Actions workflow that runs markdownlint on pull requests affecting markdown files.