### PR TITLE
Support version inference in GAV.parse from properties

### DIFF
--- a/capabilities-maven-downloader/src/main/java/ai/wanaku/capabilities/sdk/maven/GAV.java
+++ b/capabilities-maven-downloader/src/main/java/ai/wanaku/capabilities/sdk/maven/GAV.java
@@ -18,6 +18,7 @@
 package ai.wanaku.capabilities.sdk.maven;
 
 import java.util.Objects;
+import java.util.Properties;
 
 /**
  * An immutable Maven coordinate consisting of group ID, artifact ID, and version.
@@ -48,7 +49,41 @@ public record GAV(String groupId, String artifactId, String version) {
             throw new IllegalArgumentException(
                     "Invalid GAV format: expected 'groupId:artifactId:version' but got '" + gavString + "'");
         }
-        return new GAV(parts[0].trim(), parts[1].trim(), parts[2].trim());
+        return new GAV(GavUtil.group(parts), GavUtil.artifact(parts), GavUtil.version(parts));
+    }
+
+    /**
+     * Parses a colon-separated GAV string, inferring the version from the given properties
+     * when only {@code "groupId:artifactId"} is provided. Looks up the version first by
+     * {@code groupId:artifactId}, then by {@code groupId} alone.
+     *
+     * @param gavString  the GAV string to parse (2 or 3 colon-separated parts)
+     * @param properties the properties to look up versions from
+     * @return the parsed GAV
+     * @throws IllegalArgumentException if the format is invalid or the version cannot be resolved
+     */
+    public static GAV parse(String gavString, Properties properties) {
+        Objects.requireNonNull(gavString, "GAV string must not be null");
+        Objects.requireNonNull(properties, "properties must not be null");
+        String[] parts = gavString.split(":");
+        if (parts.length == 2) {
+            String groupId = GavUtil.group(parts);
+            String artifactId = GavUtil.artifact(parts);
+            String version = properties.getProperty(groupId + ":" + artifactId);
+            if (version == null) {
+                version = properties.getProperty(groupId);
+            }
+            if (version == null) {
+                throw new IllegalArgumentException(
+                        "Cannot resolve version for '%s': no matching entry in properties".formatted(gavString));
+            }
+            return new GAV(groupId, artifactId, version.trim());
+        }
+        if (parts.length == 3) {
+            return new GAV(GavUtil.group(parts), GavUtil.artifact(parts), GavUtil.version(parts));
+        }
+        throw new IllegalArgumentException(
+                "Invalid GAV format: expected 'groupId:artifactId[:version]' but got '" + gavString + "'");
     }
 
     @Override

--- a/capabilities-maven-downloader/src/main/java/ai/wanaku/capabilities/sdk/maven/GavUtil.java
+++ b/capabilities-maven-downloader/src/main/java/ai/wanaku/capabilities/sdk/maven/GavUtil.java
@@ -15,19 +15,19 @@
  * limitations under the License.
  */
 
-package ai.wanaku.capabilities.sdk.runtime.camel.util;
+package ai.wanaku.capabilities.sdk.maven;
 
 public class GavUtil {
 
-    public static String group(String gav) {
-        return gav.split(":")[0];
+    public static String group(String[] gav) {
+        return gav[0].trim();
     }
 
-    public static String artifact(String gav) {
-        return gav.split(":")[1];
+    public static String artifact(String[] gav) {
+        return gav[1].trim();
     }
 
-    public static String version(String gav) {
-        return gav.split(":")[2];
+    public static String version(String[] gav) {
+        return gav[2].trim();
     }
 }

--- a/capabilities-maven-downloader/src/test/java/ai/wanaku/capabilities/sdk/maven/GAVTest.java
+++ b/capabilities-maven-downloader/src/test/java/ai/wanaku/capabilities/sdk/maven/GAVTest.java
@@ -17,6 +17,8 @@
 
 package ai.wanaku.capabilities.sdk.maven;
 
+import java.util.Properties;
+
 import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -74,5 +76,50 @@ class GAVTest {
     @Test
     void constructorRejectsNullVersion() {
         assertThrows(NullPointerException.class, () -> new GAV("g", "a", null));
+    }
+
+    @Test
+    void parseTwoPartWithGroupIdKey() {
+        Properties props = new Properties();
+        props.setProperty("org.example", "2.0.0");
+
+        GAV gav = GAV.parse("org.example:my-lib", props);
+        assertEquals("org.example", gav.groupId());
+        assertEquals("my-lib", gav.artifactId());
+        assertEquals("2.0.0", gav.version());
+    }
+
+    @Test
+    void parseTwoPartWithSpecificKey() {
+        Properties props = new Properties();
+        props.setProperty("org.example:my-lib", "3.0.0");
+
+        GAV gav = GAV.parse("org.example:my-lib", props);
+        assertEquals("org.example", gav.groupId());
+        assertEquals("my-lib", gav.artifactId());
+        assertEquals("3.0.0", gav.version());
+    }
+
+    @Test
+    void parseTwoPartSpecificKeyTakesPrecedence() {
+        Properties props = new Properties();
+        props.setProperty("org.example", "2.0.0");
+        props.setProperty("org.example:my-lib", "3.0.0");
+
+        GAV gav = GAV.parse("org.example:my-lib", props);
+        assertEquals("3.0.0", gav.version());
+    }
+
+    @Test
+    void parseTwoPartMissingVersionThrows() {
+        Properties props = new Properties();
+        assertThrows(IllegalArgumentException.class, () -> GAV.parse("org.example:my-lib", props));
+    }
+
+    @Test
+    void parseThreePartWithPropertiesIgnoresLookup() {
+        Properties props = new Properties();
+        GAV gav = GAV.parse("org.example:my-lib:1.0", props);
+        assertEquals("1.0", gav.version());
     }
 }

--- a/capabilities-parent/pom.xml
+++ b/capabilities-parent/pom.xml
@@ -21,6 +21,7 @@
         <spotless-maven-plugin.version>3.5.1</spotless-maven-plugin.version>
 
         <camel.version>4.18.2</camel.version>
+        <forage.version>1.3</forage.version>
         <jgit.version>7.6.0.202603022253-r</jgit.version>
         <jackson-dataformat-yaml.version>2.21.3</jackson-dataformat-yaml.version>
         <jackson-databind.version>2.21.3</jackson-databind.version>
@@ -99,6 +100,13 @@
                 <version>${junit-jupiter.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
+            </dependency>
+
+            <dependency>
+                <groupId>io.kaoto.forage</groupId>
+                <artifactId>forage</artifactId>
+                <version>${forage.version}</version>
+                <scope>provided</scope>
             </dependency>
 
         </dependencies>

--- a/capabilities-runtimes/capabilities-runtimes-camel/capabilities-runtimes-camel-common/src/main/java/ai/wanaku/capabilities/sdk/runtime/camel/versions/RuntimeVersionHelper.java
+++ b/capabilities-runtimes/capabilities-runtimes-camel/capabilities-runtimes-camel-common/src/main/java/ai/wanaku/capabilities/sdk/runtime/camel/versions/RuntimeVersionHelper.java
@@ -1,0 +1,40 @@
+package ai.wanaku.capabilities.sdk.runtime.camel.versions;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Properties;
+import ai.wanaku.capabilities.sdk.common.VersionHelper;
+
+public class RuntimeVersionHelper {
+    /**
+     * The current version of this library, loaded from the "version.txt" file in the root directory.
+     */
+    public static final Properties VERSIONS;
+
+    static {
+        // Initialize the VERSION field with the contents of the "version.txt" file
+        VERSIONS = initVersions();
+    }
+
+    /**
+     * Private constructor to prevent instantiation and ensure this class is used as a utility.
+     */
+    private RuntimeVersionHelper() {}
+
+    /**
+     * Initializes and returns the version string by reading from the "version.txt" file in the root directory.
+     *
+     * @return The current version of this library.
+     */
+    private static Properties initVersions() {
+        Properties props = new Properties();
+        try (InputStream stream = VersionHelper.class.getResourceAsStream("/runtime-versions.properties")) {
+            assert stream != null;
+            props.load(stream);
+
+            return props;
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/capabilities-runtimes/capabilities-runtimes-camel/capabilities-runtimes-camel-common/src/main/java/ai/wanaku/capabilities/sdk/runtime/camel/versions/RuntimeVersionHelper.java
+++ b/capabilities-runtimes/capabilities-runtimes-camel/capabilities-runtimes-camel-common/src/main/java/ai/wanaku/capabilities/sdk/runtime/camel/versions/RuntimeVersionHelper.java
@@ -6,30 +6,30 @@ import java.util.Properties;
 import ai.wanaku.capabilities.sdk.common.VersionHelper;
 
 public class RuntimeVersionHelper {
-    /**
-     * The current version of this library, loaded from the "version.txt" file in the root directory.
-     */
-    public static final Properties VERSIONS;
+    private static final Properties VERSIONS;
 
     static {
-        // Initialize the VERSION field with the contents of the "version.txt" file
         VERSIONS = initVersions();
     }
 
-    /**
-     * Private constructor to prevent instantiation and ensure this class is used as a utility.
-     */
     private RuntimeVersionHelper() {}
 
     /**
-     * Initializes and returns the version string by reading from the "version.txt" file in the root directory.
-     *
-     * @return The current version of this library.
+     * Returns a defensive copy of the runtime version properties loaded from
+     * {@code runtime-versions.properties}.
      */
+    public static Properties getVersions() {
+        Properties copy = new Properties();
+        copy.putAll(VERSIONS);
+        return copy;
+    }
+
     private static Properties initVersions() {
         Properties props = new Properties();
         try (InputStream stream = VersionHelper.class.getResourceAsStream("/runtime-versions.properties")) {
-            assert stream != null;
+            if (stream == null) {
+                throw new IllegalStateException("Missing runtime-versions.properties on classpath");
+            }
             props.load(stream);
 
             return props;

--- a/capabilities-runtimes/capabilities-runtimes-camel/capabilities-runtimes-camel-common/src/main/resources/runtime-versions.properties
+++ b/capabilities-runtimes/capabilities-runtimes-camel/capabilities-runtimes-camel-common/src/main/resources/runtime-versions.properties
@@ -1,0 +1,3 @@
+io.kaoto.forage=${forage.version}
+org.apache.camel=${camel.version}
+dev.langchain4j=${langchain4j.version}


### PR DESCRIPTION
## Summary
- Add `GAV.parse(String, Properties)` overload that resolves the version from a properties file when only `groupId:artifactId` is provided (looks up by `groupId:artifactId` first, then falls back to `groupId`)
- Preserve backward-compatible `GAV.parse(String)` for 3-part GAV strings
- Fix `RuntimeVersionHelper` NPE where `Properties` was used before initialization
- Move `GavUtil` to `capabilities-maven-downloader` module and refactor to accept pre-split arrays

## Test plan
- [x] Existing GAV tests still pass with 1-arg `parse(String)`
- [x] New test: 2-part GAV with groupId-only key
- [x] New test: 2-part GAV with specific `groupId:artifactId` key
- [x] New test: specific key takes precedence over groupId key
- [x] New test: missing version throws `IllegalArgumentException`
- [x] New test: 3-part GAV with properties ignores lookup
- [x] Full `mvn verify` passes

## Summary by Sourcery

Support parsing GAV coordinates with optional versions resolved from runtime properties and centralize GAV utilities for reuse across modules.

New Features:
- Allow parsing of 2-part GAV strings with versions inferred from provided properties, with precedence for groupId:artifactId keys over groupId-only keys.
- Introduce a runtime version helper backed by a properties file to expose library and dependency versions at runtime.

Bug Fixes:
- Avoid potential null pointer access when loading runtime version properties by eagerly initializing the shared Properties instance.

Enhancements:
- Refactor GAV parsing to use a shared GavUtil in the maven downloader module for consistent group, artifact, and version extraction.
- Add a managed dependency on the forage library with a dedicated version property for runtime use.

Build:
- Declare a forage.version property and manage the io.kaoto.forage:forage dependency in the parent POM.

Tests:
- Extend GAV tests to cover version inference from properties, precedence rules, missing version failures, and 3-part GAV behavior when properties are provided.