### PR TITLE
Support releasing from branches instead of main

### DIFF
--- a/.github/workflows/early-access.yml
+++ b/.github/workflows/early-access.yml
@@ -3,6 +3,9 @@ name: early-access
 on:
   workflow_dispatch:
   workflow_call:
+  push:
+    branches:
+      - '[0-9]*.[0-9]*.x'
   schedule:
     # Run every 2 days at 00:00 UTC
     - cron: '0 0 */2 * *'

--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -10,7 +10,9 @@ name: Build Main
 
 on:
   push:
-    branches: [ "main" ]
+    branches:
+      - main
+      - '[0-9]*.[0-9]*.x'
 
 env:
   PROJECTS: ${{ github.workspace }}

--- a/.github/workflows/pr-builds.yml
+++ b/.github/workflows/pr-builds.yml
@@ -12,6 +12,7 @@ on:
   pull_request:
     branches:
       - "main"
+      - '[0-9]*.[0-9]*.x'
     paths-ignore:
       - .github/**
       - docs/**

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,9 @@ on:
       nextDevelopmentVersion:
         description: 'The next development version'
         required: true
+      releaseBranch:
+        description: 'The release branch (e.g., 0.2.x)'
+        required: true
 
 jobs:
   release:
@@ -22,6 +25,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          ref: ${{ github.event.inputs.releaseBranch }}
 
       # Configure build steps as you'd normally do
 

--- a/docs/release.md
+++ b/docs/release.md
@@ -1,14 +1,29 @@
 # Release Guide
 
-Export the variables:
+Releases are cut from release branches following the `X.Y.x` naming convention (e.g., `0.1.x`, `0.2.x`).
+
+## Create the release branch (first release of a minor version only)
 
 ```shell
-export CURRENT_DEVELOPMENT_VERSION=0.1.1
-export NEXT_DEVELOPMENT_VERSION=0.2.0
+git checkout main
+git checkout -b 0.2.x
+git push upstream 0.2.x
 ```
 
-Trigger the release automation:
+## Set the versions
 
 ```shell
-gh workflow run release -f currentDevelopmentVersion=${CURRENT_DEVELOPMENT_VERSION} -f nextDevelopmentVersion=${NEXT_DEVELOPMENT_VERSION}
+export RELEASE_BRANCH=0.2.x
+export CURRENT_DEVELOPMENT_VERSION=0.2.0
+export NEXT_DEVELOPMENT_VERSION=0.2.1
 ```
+
+## Trigger the release
+
+```shell
+gh workflow run release -r ${RELEASE_BRANCH} -f releaseBranch=${RELEASE_BRANCH} -f currentDevelopmentVersion=${CURRENT_DEVELOPMENT_VERSION} -f nextDevelopmentVersion=${NEXT_DEVELOPMENT_VERSION}
+```
+
+> **Note:** The `-r` flag tells GitHub to run the workflow from the release branch.
+> The `releaseBranch` input tells the workflow which branch to check out and push
+> version bump commits to.


### PR DESCRIPTION
## Summary

- Add `releaseBranch` input to `release.yml` so releases are cut from `X.Y.x` branches instead of `main`
- Add release branch triggers (`[0-9]*.[0-9]*.x`) to `main-build.yml`, `pr-builds.yml`, and `early-access.yml`
- Update `docs/release.md` with branch-based release instructions

Mirrors the approach from https://github.com/wanaku-ai/wanaku/pull/1267.

## Test plan

- [ ] Create a test release branch (e.g. `0.2.x`) and verify `main-build.yml` triggers on push
- [ ] Open a PR targeting the release branch and verify `pr-builds.yml` runs
- [ ] Dry-run the release workflow with `releaseBranch` input
- [ ] Verify `early-access.yml` publishes snapshots on release branch push

## Summary by Sourcery

Switch release workflows and builds to operate from versioned release branches instead of only main.

New Features:
- Allow the release workflow to target a configurable release branch via a new releaseBranch input.

Enhancements:
- Trigger main build and PR build workflows on versioned release branches alongside main.
- Trigger early-access workflow on pushes to versioned release branches.
- Document the branch-based release flow, including creating release branches and invoking the release workflow from them.

Documentation:
- Update the release guide to describe creating versioned release branches and running releases from those branches instead of main.