### PR TITLE
feat: add capabilities-infinispan-marshallers module and dependencies

### DIFF
--- a/capabilities-bom/pom.xml
+++ b/capabilities-bom/pom.xml
@@ -23,6 +23,11 @@
             </dependency>
             <dependency>
                 <groupId>ai.wanaku.sdk</groupId>
+                <artifactId>capabilities-infinispan-marshallers</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>ai.wanaku.sdk</groupId>
                 <artifactId>capabilities-common</artifactId>
                 <version>${project.version}</version>
             </dependency>

--- a/capabilities-infinispan-marshallers/pom.xml
+++ b/capabilities-infinispan-marshallers/pom.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>ai.wanaku.sdk</groupId>
+        <artifactId>capabilities-parent</artifactId>
+        <version>0.2.0-SNAPSHOT</version>
+        <relativePath>../capabilities-parent/pom.xml</relativePath>
+    </parent>
+
+    <artifactId>capabilities-infinispan-marshallers</artifactId>
+    <name>Wanaku Capabilities SDK :: Infinispan Marshallers</name>
+    <description>Marker interfaces for Infinispan marshaller implementations</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>ai.wanaku.sdk</groupId>
+            <artifactId>capabilities-api</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/capabilities-infinispan-marshallers/src/main/java/ai/wanaku/capabilities/sdk/api/marshaller/WanakuMarshaller.java
+++ b/capabilities-infinispan-marshallers/src/main/java/ai/wanaku/capabilities/sdk/api/marshaller/WanakuMarshaller.java
@@ -1,0 +1,13 @@
+package ai.wanaku.capabilities.sdk.api.marshaller;
+
+/**
+ * Marker interface for Wanaku Infinispan marshaller implementations.
+ * <p>
+ * This interface serves as a type identifier for marshaller classes that
+ * integrate with Infinispan's ProtoStream. It does not define any methods;
+ * implementations should also implement {@link org.infinispan.protostream.MessageMarshaller}.
+ * </p>
+ */
+public interface WanakuMarshaller {
+    // marker interface, no methods needed
+}

--- a/capabilities-parent/pom.xml
+++ b/capabilities-parent/pom.xml
@@ -41,6 +41,7 @@
         <jspecify.version>1.0.0</jspecify.version>
         <mockito.version>5.23.0</mockito.version>
         <palantir-java-format.version>2.71.0</palantir-java-format.version>
+        <infinispan.version>16.0.0.Final</infinispan.version>
     </properties>
 
     <dependencyManagement>
@@ -106,6 +107,13 @@
                 <groupId>io.kaoto.forage</groupId>
                 <artifactId>forage</artifactId>
                 <version>${forage.version}</version>
+                <scope>provided</scope>
+            </dependency>
+
+            <dependency>
+                <groupId>org.infinispan</groupId>
+                <artifactId>infinispan-protostream</artifactId>
+                <version>${infinispan.version}</version>
                 <scope>provided</scope>
             </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -67,6 +67,8 @@
 
     <modules>
         <module>capabilities-parent</module>
+        <module>capabilities-api</module>
+        <module>capabilities-infinispan-marshallers</module>
         <module>capabilities-common</module>
         <module>capabilities-discovery</module>
         <module>capabilities-security</module>
@@ -79,7 +81,6 @@
         <module>capabilities-maven-downloader</module>
         <module>capabilities-bom</module>
         <module>capabilities-archetypes</module>
-        <module>capabilities-api</module>
     </modules>
 
     <profiles>


### PR DESCRIPTION
The wanaku needs to integrate with infinispan for persistence

## Summary by Sourcery

Introduce a new Infinispan marshallers module and wire it into the multi-module Maven build and BOM.

New Features:
- Add the capabilities-infinispan-marshallers Maven module to host marker interfaces for Infinispan marshaller implementations.
- Introduce a generic WanakuMarshaller marker interface for Infinispan marshallers.

Build:
- Add Infinispan version property and infinispan-protostream provided dependency to the parent POM.
- Register the new capabilities-infinispan-marshallers module in the root Maven modules list and BOM.