### PR TITLE
feat: add request_id field to CodeExecutionRequest, ResourceRequest, and ToolInvokeRequest for tracing

### DIFF
--- a/capabilities-exchange/src/main/proto/codeexecution.proto
+++ b/capabilities-exchange/src/main/proto/codeexecution.proto
@@ -73,7 +73,13 @@ message CodeExecutionRequest {
    * These environment variables will be set in the execution context.
    */
   map<string, string> environment = 8;
-}
+
+  /**
+   * The MCP session request ID for tracing.
+   * Used to correlate requests across the system.
+   */
+  string request_id = 9;
+ }
 
 /**
  * The code execution reply message.

--- a/capabilities-exchange/src/main/proto/resourcerequest.proto
+++ b/capabilities-exchange/src/main/proto/resourcerequest.proto
@@ -19,7 +19,8 @@ message ResourceRequest {
   string name = 3;
   map<string, string> params = 4;
   string configuration_uri = 5;
-  string secrets_uri = 6;
+  string secrets_uri = 6;   
+  string request_id = 7;
 }
 
 // The resource response message

--- a/capabilities-exchange/src/main/proto/toolrequest.proto
+++ b/capabilities-exchange/src/main/proto/toolrequest.proto
@@ -19,7 +19,8 @@ message ToolInvokeRequest {
   map<string, string> arguments = 3;
   string configuration_uri = 4;
   string secrets_uri = 5;
-  map<string, string> headers = 6;
+  map<string, string> headers = 6;   
+  string request_id = 9;
 }
 
 // The invocation response message


### PR DESCRIPTION
related: https://github.com/wanaku-ai/wanaku/pull/1311#discussion_r3404169908

## Summary by Sourcery

Add a request identifier to key capability-exchange request messages to support tracing across systems.

New Features:
- Introduce a request_id field in CodeExecutionRequest messages for end-to-end request tracing.
- Add a request_id field to ResourceRequest messages to correlate resource operations with higher-level flows.
- Include a request_id field in ToolInvokeRequest messages to enable consistent tracing of tool invocations.