### PR TITLE
fix: Repetition of required field in camel tools required array

### DIFF
--- a/capabilities-runtimes/capabilities-runtimes-camel/capabilities-runtimes-camel-common/src/main/java/ai/wanaku/capabilities/sdk/runtime/camel/spec/rules/tools/WanakuToolTransformer.java
+++ b/capabilities-runtimes/capabilities-runtimes-camel/capabilities-runtimes-camel-common/src/main/java/ai/wanaku/capabilities/sdk/runtime/camel/spec/rules/tools/WanakuToolTransformer.java
@@ -13,7 +13,6 @@ public class WanakuToolTransformer implements RulesTransformer {
     public static final String DEFAULT_INPUT_SCHEMA_TYPE = "object";
     private final String name;
     private final RulesProcessor<ToolReference> processor;
-    private final List<String> required = new ArrayList<>();
 
     public WanakuToolTransformer(String name, RulesProcessor<ToolReference> processor) {
         this.name = name;
@@ -46,6 +45,7 @@ public class WanakuToolTransformer implements RulesTransformer {
         if (properties == null) {
             return;
         }
+        final List<String> required = new ArrayList<>();
 
         for (var property : properties) {
             Property wanakuProperty = new Property();


### PR DESCRIPTION
The required fields for each tool are combined into an array, and repeated fields are included for each tool.

fix for : Issue: [172](https://github.com/wanaku-ai/wanaku-capabilities-java-sdk/issues/172)

## Summary by Sourcery

Bug Fixes:
- Reset the collected required fields for each tool property set to avoid repeated entries in the generated required array.