### PR TITLE
chore: update stale SDK version in archetype test pom

### DIFF
--- a/tests/archetype-tests/build/test/pom.xml
+++ b/tests/archetype-tests/build/test/pom.xml
@@ -13,7 +13,7 @@
         <slf4j.version>2.0.16</slf4j.version>
         <log4j.version>2.21.1</log4j.version>
         <picocli.version>4.7.6</picocli.version>
-        <wanaku.sdk.version>0.2.0-SNAPSHOT</wanaku.sdk.version>
+        <wanaku.sdk.version>0.3.0-SNAPSHOT</wanaku.sdk.version>
     </properties>
 
     <dependencyManagement>

--- a/tests/archetype-tests/build/test/pom.xml
+++ b/tests/archetype-tests/build/test/pom.xml
@@ -13,7 +13,7 @@
         <slf4j.version>2.0.16</slf4j.version>
         <log4j.version>2.21.1</log4j.version>
         <picocli.version>4.7.6</picocli.version>
-        <wanaku.sdk.version>0.0.6-SNAPSHOT</wanaku.sdk.version>
+        <wanaku.sdk.version>0.2.0-SNAPSHOT</wanaku.sdk.version>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
## Summary

- Cherry-pick of #180 onto main
- Updates `wanaku.sdk.version` in `tests/archetype-tests/build/test/pom.xml` from `0.0.6-SNAPSHOT` to `0.3.0-SNAPSHOT` (matching the main branch development version)

## Test plan

- [ ] Verify archetype tests pass with the updated version