### PR TITLE
Fix static analysis violations from PMD and SpotBugs

### DIFF
--- a/capabilities-api/src/main/java/ai/wanaku/capabilities/sdk/api/types/execution/CodeExecutionRequest.java
+++ b/capabilities-api/src/main/java/ai/wanaku/capabilities/sdk/api/types/execution/CodeExecutionRequest.java
@@ -1,5 +1,6 @@
 package ai.wanaku.capabilities.sdk.api.types.execution;
 
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -90,7 +91,7 @@ public class CodeExecutionRequest {
         if (code == null || code.trim().isEmpty()) {
             throw new IllegalArgumentException("Code must not be null or empty");
         }
-        if (code.getBytes().length > MAX_CODE_SIZE_BYTES) {
+        if (code.getBytes(StandardCharsets.UTF_8).length > MAX_CODE_SIZE_BYTES) {
             throw new IllegalArgumentException(
                     "Code size exceeds maximum allowed size of " + MAX_CODE_SIZE_BYTES + " bytes");
         }
@@ -184,7 +185,7 @@ public class CodeExecutionRequest {
         if (code == null || code.trim().isEmpty()) {
             throw new IllegalArgumentException("Code must not be null or empty");
         }
-        if (code.getBytes().length > MAX_CODE_SIZE_BYTES) {
+        if (code.getBytes(StandardCharsets.UTF_8).length > MAX_CODE_SIZE_BYTES) {
             throw new IllegalArgumentException(
                     "Code size exceeds maximum allowed size of " + MAX_CODE_SIZE_BYTES + " bytes");
         }

--- a/capabilities-common/src/main/java/ai/wanaku/capabilities/sdk/common/VersionHelper.java
+++ b/capabilities-common/src/main/java/ai/wanaku/capabilities/sdk/common/VersionHelper.java
@@ -2,6 +2,7 @@ package ai.wanaku.capabilities.sdk.common;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 
 /**
  * A utility class that provides a way to retrieve Wanaku Capabilities SDK current version
@@ -32,7 +33,7 @@ public final class VersionHelper {
         try (InputStream stream = VersionHelper.class.getResourceAsStream("/version.txt")) {
             assert stream != null;
             byte[] bytes = stream.readAllBytes();
-            return new String(bytes);
+            return new String(bytes, StandardCharsets.UTF_8);
         } catch (IOException e) {
             throw new RuntimeException(e);
         }

--- a/capabilities-config-providers/capabilities-config-provider-file/src/main/java/ai/wanaku/capabilities/sdk/config/provider/file/EncryptionHelper.java
+++ b/capabilities-config-providers/capabilities-config-provider-file/src/main/java/ai/wanaku/capabilities/sdk/config/provider/file/EncryptionHelper.java
@@ -17,6 +17,7 @@ public final class EncryptionHelper {
 
     private static final String ALGORITHM = "AES/CBC/PKCS5Padding";
     private static final int IV_LENGTH = 16;
+    private static final SecureRandom SECURE_RANDOM = new SecureRandom();
 
     private EncryptionHelper() {}
 
@@ -32,7 +33,7 @@ public final class EncryptionHelper {
         byte[] key = deriveKey(password, salt);
         try {
             byte[] iv = new byte[IV_LENGTH];
-            new SecureRandom().nextBytes(iv);
+            SECURE_RANDOM.nextBytes(iv);
 
             Cipher cipher = Cipher.getInstance(ALGORITHM);
             cipher.init(Cipher.ENCRYPT_MODE, new SecretKeySpec(key, "AES"), new IvParameterSpec(iv));

--- a/capabilities-config-providers/capabilities-config-provider-file/src/main/java/ai/wanaku/capabilities/sdk/config/provider/file/FileConfigurationWriter.java
+++ b/capabilities-config-providers/capabilities-config-provider-file/src/main/java/ai/wanaku/capabilities/sdk/config/provider/file/FileConfigurationWriter.java
@@ -3,6 +3,7 @@ package ai.wanaku.capabilities.sdk.config.provider.file;
 import java.io.File;
 import java.io.IOException;
 import java.net.URI;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -25,7 +26,7 @@ public class FileConfigurationWriter implements ConfigWriter {
     public URI write(String id, String data) {
         try {
             final Path path = Paths.get(serviceHome.getAbsolutePath(), id);
-            Files.write(path, data.getBytes());
+            Files.write(path, data.getBytes(StandardCharsets.UTF_8));
 
             return path.toUri();
         } catch (IOException e) {

--- a/capabilities-data-files/src/main/java/ai/wanaku/capabilities/sdk/data/files/InstanceDataReader.java
+++ b/capabilities-data-files/src/main/java/ai/wanaku/capabilities/sdk/data/files/InstanceDataReader.java
@@ -5,6 +5,7 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
+import java.nio.charset.StandardCharsets;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import ai.wanaku.capabilities.sdk.api.types.providers.ServiceType;
@@ -22,7 +23,7 @@ public class InstanceDataReader implements AutoCloseable {
     private final FileHeader fileHeader;
 
     static {
-        assert (((FileHeader.BYTES + ServiceEntry.BYTES) % 20) == 0)
+        assert ((FileHeader.BYTES + ServiceEntry.BYTES) % 20) == 0
                 : "File header and the file entries must be aligned on a 20 bytes boundary";
     }
 
@@ -63,7 +64,7 @@ public class InstanceDataReader implements AutoCloseable {
 
         byte[] name = new byte[FileHeader.FORMAT_NAME_SIZE];
         byteBuffer.get(name, 0, FileHeader.FORMAT_NAME_SIZE);
-        LOG.trace("File format name: '{}'", new String(name));
+        LOG.trace("File format name: '{}'", new String(name, StandardCharsets.UTF_8));
 
         int fileVersion = byteBuffer.getInt();
         LOG.trace("File version: '{}'", fileVersion);
@@ -71,7 +72,7 @@ public class InstanceDataReader implements AutoCloseable {
         ServiceType serviceType = ServiceType.fromIntValue(byteBuffer.getInt());
         LOG.trace("Role: '{}'", serviceType.intValue());
 
-        return new FileHeader(new String(name), serviceType, fileVersion);
+        return new FileHeader(new String(name, StandardCharsets.UTF_8), serviceType, fileVersion);
     }
 
     /**
@@ -86,7 +87,7 @@ public class InstanceDataReader implements AutoCloseable {
             byte[] idBytes = new byte[ServiceEntry.ID_LENGTH];
             byteBuffer.get(idBytes, 0, ServiceEntry.ID_LENGTH);
 
-            return new ServiceEntry(new String(idBytes));
+            return new ServiceEntry(new String(idBytes, StandardCharsets.UTF_8));
         }
 
         byteBuffer.compact();
@@ -99,7 +100,7 @@ public class InstanceDataReader implements AutoCloseable {
         byte[] idBytes = new byte[ServiceEntry.ID_LENGTH];
         byteBuffer.get(idBytes, 0, ServiceEntry.ID_LENGTH);
 
-        return new ServiceEntry(new String(idBytes));
+        return new ServiceEntry(new String(idBytes, StandardCharsets.UTF_8));
     }
 
     /**

--- a/capabilities-data-files/src/main/java/ai/wanaku/capabilities/sdk/data/files/InstanceDataWriter.java
+++ b/capabilities-data-files/src/main/java/ai/wanaku/capabilities/sdk/data/files/InstanceDataWriter.java
@@ -5,6 +5,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
+import java.nio.charset.StandardCharsets;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -54,7 +55,7 @@ public class InstanceDataWriter implements AutoCloseable {
      */
     private void writeHeader(final FileHeader header) throws IOException {
         byteBuffer.clear();
-        byteBuffer.put(header.getFormatName().getBytes());
+        byteBuffer.put(header.getFormatName().getBytes(StandardCharsets.UTF_8));
         byteBuffer.putInt(header.getFileVersion());
         byteBuffer.putInt(header.getServiceType().intValue());
 
@@ -78,7 +79,7 @@ public class InstanceDataWriter implements AutoCloseable {
                     "Service entry id too long (it must not exceed the length of " + ServiceEntry.BYTES + ")");
         }
 
-        byteBuffer.put(entry.getId().getBytes());
+        byteBuffer.put(entry.getId().getBytes(StandardCharsets.UTF_8));
     }
 
     /**

--- a/capabilities-discovery/src/main/java/ai/wanaku/capabilities/sdk/discovery/ZeroDepRegistrationManager.java
+++ b/capabilities-discovery/src/main/java/ai/wanaku/capabilities/sdk/discovery/ZeroDepRegistrationManager.java
@@ -155,10 +155,11 @@ public class ZeroDepRegistrationManager implements RegistrationManager {
     private int waitAndRetry(String serviceName, Exception e, int currentRetries, int waitSeconds) {
         if (currentRetries > 0) {
             LOG.info(
-                    "Retrying registration for service {} in {} seconds. Retries left: {}",
+                    "Retrying registration for service {} in {} seconds. Retries left: {}. Cause: {}",
                     serviceName,
                     waitSeconds,
-                    currentRetries - 1);
+                    currentRetries - 1,
+                    e.getMessage());
             try {
                 Thread.sleep(waitSeconds * 1000L);
             } catch (InterruptedException ie) {

--- a/capabilities-runtimes/capabilities-runtimes-camel/capabilities-runtimes-camel-common/src/main/java/ai/wanaku/capabilities/sdk/runtime/camel/grpc/CamelResource.java
+++ b/capabilities-runtimes/capabilities-runtimes-camel/capabilities-runtimes-camel-common/src/main/java/ai/wanaku/capabilities/sdk/runtime/camel/grpc/CamelResource.java
@@ -67,7 +67,7 @@ public class CamelResource extends ResourceAcquirerGrpc.ResourceAcquirerImplBase
             return;
         }
 
-        try (final ConsumerTemplate consumerTemplate = ctx.createConsumerTemplate()) {
+        try (ConsumerTemplate consumerTemplate = ctx.createConsumerTemplate()) {
             final String endpointUri = resolveEndpoint(definition, ctx);
             LOG.info("Consuming from {} as {}", endpointUri, routeUri);
 

--- a/capabilities-runtimes/capabilities-runtimes-camel/capabilities-runtimes-camel-common/src/main/java/ai/wanaku/capabilities/sdk/runtime/camel/init/GitInitializer.java
+++ b/capabilities-runtimes/capabilities-runtimes-camel/capabilities-runtimes-camel-common/src/main/java/ai/wanaku/capabilities/sdk/runtime/camel/init/GitInitializer.java
@@ -42,7 +42,7 @@ public class GitInitializer implements Initializer {
 
         LOG.info("Cloning git repository from {} to {}", gitRepoUrl, clonedRepoPath);
 
-        try (Git git = Git.cloneRepository()
+        try (Git ignored = Git.cloneRepository()
                 .setURI(gitRepoUrl)
                 .setDirectory(clonedRepoDir)
                 .call()) {

--- a/capabilities-runtimes/capabilities-runtimes-camel/capabilities-runtimes-camel-common/src/main/java/ai/wanaku/capabilities/sdk/runtime/camel/spec/rules/tools/mapping/AutoMapper.java
+++ b/capabilities-runtimes/capabilities-runtimes-camel/capabilities-runtimes-camel-common/src/main/java/ai/wanaku/capabilities/sdk/runtime/camel/spec/rules/tools/mapping/AutoMapper.java
@@ -2,16 +2,12 @@ package ai.wanaku.capabilities.sdk.runtime.camel.spec.rules.tools.mapping;
 
 import java.util.HashMap;
 import java.util.Map;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import ai.wanaku.capabilities.sdk.runtime.camel.model.Definition;
 import ai.wanaku.core.exchange.v1.ToolInvokeRequest;
 
 public class AutoMapper implements HeaderMapper {
-    private static final Logger LOG = LoggerFactory.getLogger(AutoMapper.class);
 
-    private static Map<String, Object> convertMcpMapToCamelHeaders(
-            Definition toolDefinition, Map<String, String> argumentsMap) {
+    private static Map<String, Object> convertMcpMapToCamelHeaders(Map<String, String> argumentsMap) {
         Map<String, Object> headers = new HashMap<>();
 
         for (var entry : argumentsMap.entrySet()) {
@@ -24,6 +20,6 @@ public class AutoMapper implements HeaderMapper {
     @Override
     public Map<String, Object> map(ToolInvokeRequest request, Definition toolDefinition) {
         final Map<String, String> argumentsMap = request.getArgumentsMap();
-        return convertMcpMapToCamelHeaders(toolDefinition, argumentsMap);
+        return convertMcpMapToCamelHeaders(argumentsMap);
     }
 }


### PR DESCRIPTION
## Summary
- Fix all PMD and SpotBugs violations across the codebase
- Use `StandardCharsets.UTF_8` for all `String.getBytes()` and `new String(byte[])` calls (DM_DEFAULT_ENCODING)
- Reuse `SecureRandom` instance as a static field instead of creating per-call (DMI_RANDOM_USED_ONLY_ONCE)
- Remove useless parentheses, unused fields/parameters, unnecessary modifiers (PMD)
- Log exception cause in retry messages instead of discarding it

## Test plan
- [x] Full build with tests passes (`mvn verify -B`)
- [x] Static analysis passes (`mvn verify -Pstatic-analysis -DskipTests -B`)

## Summary by Sourcery

Address static analysis findings across the codebase, tightening encoding handling, cryptographic randomness usage, and logging.

Bug Fixes:
- Use explicit UTF-8 charset for all string-to-byte and byte-to-string conversions to avoid platform-dependent behavior.
- Reuse a single SecureRandom instance for IV generation to prevent inefficient per-call initialization.
- Include the exception cause in service registration retry log messages for better observability.

Enhancements:
- Remove unused parameters, redundant variables, and unnecessary parentheses to satisfy PMD and SpotBugs and simplify code.
- Adjust resource handling patterns in Camel runtime components for cleaner try-with-resources usage.