### PR TITLE
fix: validate required parameters before invoking Camel route

### DIFF
--- a/capabilities-runtimes/capabilities-runtimes-camel/capabilities-runtimes-camel-common/src/main/java/ai/wanaku/capabilities/sdk/runtime/camel/grpc/CamelTool.java
+++ b/capabilities-runtimes/capabilities-runtimes-camel/capabilities-runtimes-camel-common/src/main/java/ai/wanaku/capabilities/sdk/runtime/camel/grpc/CamelTool.java
@@ -136,7 +136,7 @@ public class CamelTool extends ToolInvokerGrpc.ToolInvokerImplBase {
         return toolDefinition.getProperties().stream()
                 .filter(Property::isRequired)
                 .map(Property::getName)
-                .filter(name -> !arguments.containsKey(name))
+                .filter(name -> name != null && !arguments.containsKey(name))
                 .toList();
     }
 }

--- a/capabilities-runtimes/capabilities-runtimes-camel/capabilities-runtimes-camel-common/src/main/java/ai/wanaku/capabilities/sdk/runtime/camel/grpc/CamelTool.java
+++ b/capabilities-runtimes/capabilities-runtimes-camel/capabilities-runtimes-camel-common/src/main/java/ai/wanaku/capabilities/sdk/runtime/camel/grpc/CamelTool.java
@@ -14,6 +14,7 @@ import io.grpc.Status;
 import io.grpc.stub.StreamObserver;
 import ai.wanaku.capabilities.sdk.runtime.camel.model.Definition;
 import ai.wanaku.capabilities.sdk.runtime.camel.model.McpSpec;
+import ai.wanaku.capabilities.sdk.runtime.camel.model.Property;
 import ai.wanaku.capabilities.sdk.runtime.camel.spec.rules.tools.mapping.HeaderMapper;
 import ai.wanaku.capabilities.sdk.runtime.camel.spec.rules.tools.mapping.HeaderMapperFactory;
 import ai.wanaku.core.exchange.v1.ToolInvokeReply;
@@ -69,6 +70,15 @@ public class CamelTool extends ToolInvokerGrpc.ToolInvokerImplBase {
             return;
         }
 
+        List<String> missingParams = findMissingRequiredParameters(toolDefinition, request.getArgumentsMap());
+        if (!missingParams.isEmpty()) {
+            LOG.warn("Missing required parameter(s) for tool {}: {}", host, missingParams);
+            responseObserver.onError(Status.INVALID_ARGUMENT
+                    .withDescription("Missing required parameter(s): " + String.join(", ", missingParams))
+                    .asRuntimeException());
+            return;
+        }
+
         final String endpointUri = resolveEndpoint(toolDefinition, ctx);
 
         try (ProducerTemplate producerTemplate = ctx.createProducerTemplate()) {
@@ -116,5 +126,17 @@ public class CamelTool extends ToolInvokerGrpc.ToolInvokerImplBase {
         HeaderMapper headerMapper = HeaderMapperFactory.create(toolDefinition);
 
         return headerMapper.map(request, toolDefinition);
+    }
+
+    static List<String> findMissingRequiredParameters(Definition toolDefinition, Map<String, String> arguments) {
+        if (toolDefinition.getProperties() == null) {
+            return List.of();
+        }
+
+        return toolDefinition.getProperties().stream()
+                .filter(Property::isRequired)
+                .map(Property::getName)
+                .filter(name -> !arguments.containsKey(name))
+                .toList();
     }
 }

--- a/capabilities-runtimes/capabilities-runtimes-camel/capabilities-runtimes-camel-common/src/test/java/ai/wanaku/capabilities/sdk/runtime/camel/grpc/CamelToolTest.java
+++ b/capabilities-runtimes/capabilities-runtimes-camel/capabilities-runtimes-camel-common/src/test/java/ai/wanaku/capabilities/sdk/runtime/camel/grpc/CamelToolTest.java
@@ -33,7 +33,9 @@ class CamelToolTest {
         Definition definition = definitionWithProperties(requiredProperty("city"), requiredProperty("country"));
         List<String> missing = CamelTool.findMissingRequiredParameters(definition, Map.of());
 
-        assertEquals(List.of("city", "country"), missing);
+        assertEquals(2, missing.size());
+        assertTrue(missing.contains("city"));
+        assertTrue(missing.contains("country"));
     }
 
     @Test
@@ -54,6 +56,17 @@ class CamelToolTest {
         List<String> missing = CamelTool.findMissingRequiredParameters(definition, Map.of());
 
         assertTrue(missing.isEmpty());
+    }
+
+    @Test
+    void findMissingRequiredParametersIgnoresNullName() {
+        Property nullName = new Property();
+        nullName.setRequired(true);
+
+        Definition definition = definitionWithProperties(requiredProperty("city"), nullName);
+        List<String> missing = CamelTool.findMissingRequiredParameters(definition, Map.of());
+
+        assertEquals(List.of("city"), missing);
     }
 
     @Test

--- a/capabilities-runtimes/capabilities-runtimes-camel/capabilities-runtimes-camel-common/src/test/java/ai/wanaku/capabilities/sdk/runtime/camel/grpc/CamelToolTest.java
+++ b/capabilities-runtimes/capabilities-runtimes-camel/capabilities-runtimes-camel-common/src/test/java/ai/wanaku/capabilities/sdk/runtime/camel/grpc/CamelToolTest.java
@@ -1,0 +1,83 @@
+package ai.wanaku.capabilities.sdk.runtime.camel.grpc;
+
+import java.util.List;
+import java.util.Map;
+import ai.wanaku.capabilities.sdk.runtime.camel.model.Definition;
+import ai.wanaku.capabilities.sdk.runtime.camel.model.Property;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class CamelToolTest {
+
+    @Test
+    void findMissingRequiredParametersReturnsEmptyWhenAllPresent() {
+        Definition definition = definitionWithProperties(requiredProperty("city"), requiredProperty("country"));
+        List<String> missing =
+                CamelTool.findMissingRequiredParameters(definition, Map.of("city", "London", "country", "UK"));
+
+        assertTrue(missing.isEmpty());
+    }
+
+    @Test
+    void findMissingRequiredParametersReportsMissing() {
+        Definition definition = definitionWithProperties(requiredProperty("city"), requiredProperty("country"));
+        List<String> missing = CamelTool.findMissingRequiredParameters(definition, Map.of("city", "London"));
+
+        assertEquals(List.of("country"), missing);
+    }
+
+    @Test
+    void findMissingRequiredParametersReportsAllMissing() {
+        Definition definition = definitionWithProperties(requiredProperty("city"), requiredProperty("country"));
+        List<String> missing = CamelTool.findMissingRequiredParameters(definition, Map.of());
+
+        assertEquals(List.of("city", "country"), missing);
+    }
+
+    @Test
+    void findMissingRequiredParametersIgnoresOptional() {
+        Property optional = new Property();
+        optional.setName("format");
+        optional.setRequired(false);
+
+        Definition definition = definitionWithProperties(requiredProperty("city"), optional);
+        List<String> missing = CamelTool.findMissingRequiredParameters(definition, Map.of());
+
+        assertEquals(List.of("city"), missing);
+    }
+
+    @Test
+    void findMissingRequiredParametersHandlesNullProperties() {
+        Definition definition = new Definition();
+        List<String> missing = CamelTool.findMissingRequiredParameters(definition, Map.of());
+
+        assertTrue(missing.isEmpty());
+    }
+
+    @Test
+    void findMissingRequiredParametersHandlesNoRequiredProperties() {
+        Property optional = new Property();
+        optional.setName("format");
+        optional.setRequired(false);
+
+        Definition definition = definitionWithProperties(optional);
+        List<String> missing = CamelTool.findMissingRequiredParameters(definition, Map.of());
+
+        assertTrue(missing.isEmpty());
+    }
+
+    private static Property requiredProperty(String name) {
+        Property property = new Property();
+        property.setName(name);
+        property.setRequired(true);
+        return property;
+    }
+
+    private static Definition definitionWithProperties(Property... properties) {
+        Definition definition = new Definition();
+        definition.setProperties(List.of(properties));
+        return definition;
+    }
+}


### PR DESCRIPTION
## Summary

- Adds required parameter validation in `CamelTool.invokeTool()` before invoking the Camel route
- Missing required params now return gRPC `INVALID_ARGUMENT` (maps to JSON-RPC `-32602`) instead of letting the route fail with `INTERNAL` (`-32603`)
- Null-named properties are safely skipped to avoid misleading error messages

## Details

The `Definition` model carries `Property` objects with a `required` flag, but `CamelTool` never checked them. When a required parameter was missing, the Camel route would fail (or hang), producing a generic Internal Error that gave the caller no diagnostic information.

The new `findMissingRequiredParameters()` method checks the tool definition's properties against the request arguments and short-circuits with a clear error message listing the missing parameter names.

## Test plan

- [x] 7 unit tests added for `findMissingRequiredParameters` (all present, one missing, all missing, optional ignored, null properties, no required, null name)
- [ ] Integration test update in `wanaku-ai/wanaku-tests` (companion PR)

Ref: orpiske/camel-integration-capability#127

## Summary by Sourcery

Validate required tool parameters before invoking Camel routes and surface clear client-facing errors when required inputs are missing.

Bug Fixes:
- Return INVALID_ARGUMENT errors when required tool parameters are missing instead of allowing Camel routes to fail with internal errors.

Enhancements:
- Add pre-invocation validation of required tool properties in CamelTool based on the tool definition metadata.

Tests:
- Add unit tests covering required-parameter validation across present, missing, optional, null-property, and no-required-property scenarios.