### PR TITLE
fix #190: reject gRPC tool/resource calls before Camel routes are started

### DIFF
--- a/capabilities-runtimes/capabilities-runtimes-camel/capabilities-runtimes-camel-common/src/main/java/ai/wanaku/capabilities/sdk/runtime/camel/grpc/CamelResource.java
+++ b/capabilities-runtimes/capabilities-runtimes-camel/capabilities-runtimes-camel-common/src/main/java/ai/wanaku/capabilities/sdk/runtime/camel/grpc/CamelResource.java
@@ -52,6 +52,12 @@ public class CamelResource extends ResourceAcquirerGrpc.ResourceAcquirerImplBase
         }
 
         final CamelContext ctx = info.camelContext();
+        if (!ctx.getStatus().isStarted()) {
+            responseObserver.onError(Status.FAILED_PRECONDITION
+                    .withDescription("Camel context is not yet available")
+                    .asRuntimeException());
+            return;
+        }
         final String uri = request.getLocation();
         URI routeUri = URI.create(uri);
         final String host = routeUri.getHost();

--- a/capabilities-runtimes/capabilities-runtimes-camel/capabilities-runtimes-camel-common/src/main/java/ai/wanaku/capabilities/sdk/runtime/camel/grpc/CamelTool.java
+++ b/capabilities-runtimes/capabilities-runtimes-camel/capabilities-runtimes-camel-common/src/main/java/ai/wanaku/capabilities/sdk/runtime/camel/grpc/CamelTool.java
@@ -55,6 +55,12 @@ public class CamelTool extends ToolInvokerGrpc.ToolInvokerImplBase {
         }
 
         final CamelContext ctx = info.camelContext();
+        if (!ctx.getStatus().isStarted()) {
+            responseObserver.onError(Status.FAILED_PRECONDITION
+                    .withDescription("Camel context is not yet available")
+                    .asRuntimeException());
+            return;
+        }
         final String uri = request.getUri();
         final URI routeUri = URI.create(uri);
         final String host = routeUri.getHost();

--- a/capabilities-runtimes/capabilities-runtimes-camel/capabilities-runtimes-camel-common/src/test/java/ai/wanaku/capabilities/sdk/runtime/camel/grpc/WanakuRegistrationInfoResolverTest.java
+++ b/capabilities-runtimes/capabilities-runtimes-camel/capabilities-runtimes-camel-common/src/test/java/ai/wanaku/capabilities/sdk/runtime/camel/grpc/WanakuRegistrationInfoResolverTest.java
@@ -1,0 +1,67 @@
+package ai.wanaku.capabilities.sdk.runtime.camel.grpc;
+
+import java.util.concurrent.CompletableFuture;
+import org.apache.camel.CamelContext;
+import org.apache.camel.impl.DefaultCamelContext;
+import io.grpc.Status;
+import io.grpc.StatusRuntimeException;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class WanakuRegistrationInfoResolverTest {
+
+    @Test
+    void resolveThrowsFailedPreconditionWhenFutureNotDone() {
+        CompletableFuture<WanakuRegistrationInfo> future = new CompletableFuture<>();
+        WanakuRegistrationInfoResolver resolver = new WanakuRegistrationInfoResolver(future);
+
+        StatusRuntimeException ex = assertThrows(StatusRuntimeException.class, resolver::resolve);
+        assertEquals(Status.FAILED_PRECONDITION.getCode(), ex.getStatus().getCode());
+    }
+
+    @Test
+    void resolveReturnsInfoWhenContextNotYetStarted() {
+        CamelContext context = new DefaultCamelContext();
+        WanakuRegistrationInfo info = new WanakuRegistrationInfo(context, null, null);
+        CompletableFuture<WanakuRegistrationInfo> future = CompletableFuture.completedFuture(info);
+        WanakuRegistrationInfoResolver resolver = new WanakuRegistrationInfoResolver(future);
+
+        assertNotNull(resolver.resolve());
+    }
+
+    @Test
+    void resolveSucceedsWhenContextStarted() throws Exception {
+        CamelContext context = new DefaultCamelContext();
+        context.start();
+        try {
+            WanakuRegistrationInfo info = new WanakuRegistrationInfo(context, null, null);
+            CompletableFuture<WanakuRegistrationInfo> future = CompletableFuture.completedFuture(info);
+            WanakuRegistrationInfoResolver resolver = new WanakuRegistrationInfoResolver(future);
+
+            assertNotNull(resolver.resolve());
+        } finally {
+            context.stop();
+        }
+    }
+
+    @Test
+    void resolveReturnsCachedInstanceOnSubsequentCalls() throws Exception {
+        CamelContext context = new DefaultCamelContext();
+        context.start();
+        try {
+            WanakuRegistrationInfo info = new WanakuRegistrationInfo(context, null, null);
+            CompletableFuture<WanakuRegistrationInfo> future = CompletableFuture.completedFuture(info);
+            WanakuRegistrationInfoResolver resolver = new WanakuRegistrationInfoResolver(future);
+
+            WanakuRegistrationInfo first = resolver.resolve();
+            WanakuRegistrationInfo second = resolver.resolve();
+            assertSame(first, second);
+        } finally {
+            context.stop();
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Add CamelContext `isStarted()` check in `CamelTool` and `CamelResource` gRPC services to reject calls that arrive before Camel routes are fully started
- The check is placed in each service (not the shared `WanakuRegistrationInfoResolver`) so that `CamelHealthProbe` can still report intermediate lifecycle states during startup
- Add `WanakuRegistrationInfoResolverTest` with 4 tests covering: future not done, context not started, context started, and cached instance

Fixes #190

## Test plan

- [x] Unit tests pass (`mvn test`)
- [x] Static analysis passes (`mvn verify -Pstatic-analysis`)
- [ ] Integration tests (`CamelMultiInstanceITCase`) should no longer see race condition failures

## Summary by Sourcery

Reject gRPC tool and resource calls when the Camel context is not fully started to avoid race conditions during startup.

Bug Fixes:
- Return FAILED_PRECONDITION for CamelTool gRPC invocations received before the Camel context has started.
- Return FAILED_PRECONDITION for CamelResource gRPC invocations received before the Camel context has started.

Tests:
- Add WanakuRegistrationInfoResolverTest covering future-not-done, context-not-started, context-started, and cached-instance behaviors.