### PR TITLE
chore: add @Nullable annotations to Namespace.name

### DIFF
--- a/capabilities-api/src/main/java/ai/wanaku/capabilities/sdk/api/types/Namespace.java
+++ b/capabilities-api/src/main/java/ai/wanaku/capabilities/sdk/api/types/Namespace.java
@@ -1,5 +1,7 @@
 package ai.wanaku.capabilities.sdk.api.types;
 
+import org.jspecify.annotations.Nullable;
+
 /**
  * Represents a namespace within the Wanaku system.
  * <p>
@@ -14,7 +16,7 @@ public class Namespace extends LabelsAwareEntity<String> {
     public Namespace() {}
 
     private String id;
-    private String name;
+    private @Nullable String name;
     private String path;
 
     /**
@@ -42,7 +44,7 @@ public class Namespace extends LabelsAwareEntity<String> {
      *
      * @return the namespace name
      */
-    public String getName() {
+    public @Nullable String getName() {
         return name;
     }
 
@@ -51,7 +53,7 @@ public class Namespace extends LabelsAwareEntity<String> {
      *
      * @param name the namespace name to set
      */
-    public void setName(String name) {
+    public void setName(@Nullable String name) {
         this.name = name;
     }
 


### PR DESCRIPTION
## Summary
- The `types` package is `@NullMarked` but the `name` field on `Namespace` can legitimately be null
- Added `@Nullable` to the field declaration, getter return type, and setter parameter for consistency

## Test plan
- [x] Module compiles cleanly
- [x] Adversarial code review passed (all findings LOW, no blockers)

## Summary by Sourcery

Enhancements:
- Import jspecify @Nullable and apply it to the Namespace.name field, getter return type, and setter parameter for null-safety correctness.