### PR TITLE
[backport 0.2.x] fix #190 + @Nullable Namespace.name

### DIFF
--- a/capabilities-api/src/main/java/ai/wanaku/capabilities/sdk/api/types/Namespace.java
+++ b/capabilities-api/src/main/java/ai/wanaku/capabilities/sdk/api/types/Namespace.java
@@ -1,5 +1,7 @@
 package ai.wanaku.capabilities.sdk.api.types;
 
+import org.jspecify.annotations.Nullable;
+
 /**
  * Represents a namespace within the Wanaku system.
  * <p>
@@ -14,7 +16,7 @@ public class Namespace extends LabelsAwareEntity<String> {
     public Namespace() {}
 
     private String id;
-    private String name;
+    private @Nullable String name;
     private String path;
 
     /**
@@ -42,7 +44,7 @@ public class Namespace extends LabelsAwareEntity<String> {
      *
      * @return the namespace name
      */
-    public String getName() {
+    public @Nullable String getName() {
         return name;
     }
 
@@ -51,7 +53,7 @@ public class Namespace extends LabelsAwareEntity<String> {
      *
      * @param name the namespace name to set
      */
-    public void setName(String name) {
+    public void setName(@Nullable String name) {
         this.name = name;
     }
 

--- a/capabilities-runtimes/capabilities-runtimes-camel/capabilities-runtimes-camel-common/src/main/java/ai/wanaku/capabilities/sdk/runtime/camel/grpc/CamelResource.java
+++ b/capabilities-runtimes/capabilities-runtimes-camel/capabilities-runtimes-camel-common/src/main/java/ai/wanaku/capabilities/sdk/runtime/camel/grpc/CamelResource.java
@@ -52,6 +52,12 @@ public class CamelResource extends ResourceAcquirerGrpc.ResourceAcquirerImplBase
         }
 
         final CamelContext ctx = info.camelContext();
+        if (!ctx.getStatus().isStarted()) {
+            responseObserver.onError(Status.FAILED_PRECONDITION
+                    .withDescription("Camel context is not yet available")
+                    .asRuntimeException());
+            return;
+        }
         final String uri = request.getLocation();
         URI routeUri = URI.create(uri);
         final String host = routeUri.getHost();

--- a/capabilities-runtimes/capabilities-runtimes-camel/capabilities-runtimes-camel-common/src/main/java/ai/wanaku/capabilities/sdk/runtime/camel/grpc/CamelTool.java
+++ b/capabilities-runtimes/capabilities-runtimes-camel/capabilities-runtimes-camel-common/src/main/java/ai/wanaku/capabilities/sdk/runtime/camel/grpc/CamelTool.java
@@ -55,6 +55,12 @@ public class CamelTool extends ToolInvokerGrpc.ToolInvokerImplBase {
         }
 
         final CamelContext ctx = info.camelContext();
+        if (!ctx.getStatus().isStarted()) {
+            responseObserver.onError(Status.FAILED_PRECONDITION
+                    .withDescription("Camel context is not yet available")
+                    .asRuntimeException());
+            return;
+        }
         final String uri = request.getUri();
         final URI routeUri = URI.create(uri);
         final String host = routeUri.getHost();

--- a/capabilities-runtimes/capabilities-runtimes-camel/capabilities-runtimes-camel-common/src/test/java/ai/wanaku/capabilities/sdk/runtime/camel/grpc/WanakuRegistrationInfoResolverTest.java
+++ b/capabilities-runtimes/capabilities-runtimes-camel/capabilities-runtimes-camel-common/src/test/java/ai/wanaku/capabilities/sdk/runtime/camel/grpc/WanakuRegistrationInfoResolverTest.java
@@ -1,0 +1,67 @@
+package ai.wanaku.capabilities.sdk.runtime.camel.grpc;
+
+import java.util.concurrent.CompletableFuture;
+import org.apache.camel.CamelContext;
+import org.apache.camel.impl.DefaultCamelContext;
+import io.grpc.Status;
+import io.grpc.StatusRuntimeException;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class WanakuRegistrationInfoResolverTest {
+
+    @Test
+    void resolveThrowsFailedPreconditionWhenFutureNotDone() {
+        CompletableFuture<WanakuRegistrationInfo> future = new CompletableFuture<>();
+        WanakuRegistrationInfoResolver resolver = new WanakuRegistrationInfoResolver(future);
+
+        StatusRuntimeException ex = assertThrows(StatusRuntimeException.class, resolver::resolve);
+        assertEquals(Status.FAILED_PRECONDITION.getCode(), ex.getStatus().getCode());
+    }
+
+    @Test
+    void resolveReturnsInfoWhenContextNotYetStarted() {
+        CamelContext context = new DefaultCamelContext();
+        WanakuRegistrationInfo info = new WanakuRegistrationInfo(context, null, null);
+        CompletableFuture<WanakuRegistrationInfo> future = CompletableFuture.completedFuture(info);
+        WanakuRegistrationInfoResolver resolver = new WanakuRegistrationInfoResolver(future);
+
+        assertNotNull(resolver.resolve());
+    }
+
+    @Test
+    void resolveSucceedsWhenContextStarted() throws Exception {
+        CamelContext context = new DefaultCamelContext();
+        context.start();
+        try {
+            WanakuRegistrationInfo info = new WanakuRegistrationInfo(context, null, null);
+            CompletableFuture<WanakuRegistrationInfo> future = CompletableFuture.completedFuture(info);
+            WanakuRegistrationInfoResolver resolver = new WanakuRegistrationInfoResolver(future);
+
+            assertNotNull(resolver.resolve());
+        } finally {
+            context.stop();
+        }
+    }
+
+    @Test
+    void resolveReturnsCachedInstanceOnSubsequentCalls() throws Exception {
+        CamelContext context = new DefaultCamelContext();
+        context.start();
+        try {
+            WanakuRegistrationInfo info = new WanakuRegistrationInfo(context, null, null);
+            CompletableFuture<WanakuRegistrationInfo> future = CompletableFuture.completedFuture(info);
+            WanakuRegistrationInfoResolver resolver = new WanakuRegistrationInfoResolver(future);
+
+            WanakuRegistrationInfo first = resolver.resolve();
+            WanakuRegistrationInfo second = resolver.resolve();
+            assertSame(first, second);
+        } finally {
+            context.stop();
+        }
+    }
+}


### PR DESCRIPTION
## Backport of #191 and #192

Cherry-pick of #191 and #192 onto `0.2.x`.

**Original PRs:**
- #191 - fix #190: reject gRPC tool/resource calls before Camel routes are started
- #192 - chore: add @Nullable annotations to Namespace.name

**Original author:** @orpiske
**Target branch:** `0.2.x`

### Original descriptions

**PR #191:** Add `CamelContext.isStarted()` check in `CamelTool` and `CamelResource` gRPC services to reject calls that arrive before Camel routes are fully started. Adds `WanakuRegistrationInfoResolverTest` with 4 tests.

**PR #192:** The `types` package is `@NullMarked` but the `name` field on `Namespace` can legitimately be null. Added `@Nullable` to the field, getter, and setter for consistency.

## Summary by Sourcery

Backport gRPC Camel runtime safety checks for unstarted contexts and align Namespace.name nullability with the types package annotations, including tests for registration info resolution behavior.

Bug Fixes:
- Reject gRPC tool and resource invocations when the Camel context has not yet started, returning FAILED_PRECONDITION errors instead of proceeding.

Enhancements:
- Allow Namespace.name to be explicitly nullable with @Nullable annotations for the field, getter, and setter.

Tests:
- Add WanakuRegistrationInfoResolver tests to cover precondition failures, behavior before Camel context start, successful resolution after start, and caching on subsequent calls.