### PR TITLE
chore: remove deprecated state methods and unused discovery client methods

### DIFF
--- a/capabilities-api/src/main/java/ai/wanaku/capabilities/sdk/api/discovery/RegistrationManager.java
+++ b/capabilities-api/src/main/java/ai/wanaku/capabilities/sdk/api/discovery/RegistrationManager.java
@@ -23,26 +23,6 @@ public interface RegistrationManager {
     void deregister();
 
     /**
-     * Notifies the Wanaku registration system that the last attempted operation (tool call
-     * or resource acquisition) from this service failed.
-     *
-     * @param reason A descriptive string explaining the reason for the failure.
-     * This information can be used for logging, debugging, or alerting purposes
-     * by the registration system.
-     */
-    @Deprecated(forRemoval = true)
-    default void lastAsFail(String reason) {}
-
-    /**
-     * Notifies the Wanaku registration system that the last attempted operation (tool call
-     * or resource acquisition) from this service was successful.
-     * This method can be used to update the service's status within the registry,
-     * indicating its continued health and availability.
-     */
-    @Deprecated(forRemoval = true)
-    default void lastAsSuccessful() {}
-
-    /**
      * Adds a callback to be run after some operations have executed
      * @param callback the callback to add
      */

--- a/capabilities-discovery/src/main/java/ai/wanaku/capabilities/sdk/discovery/DiscoveryServiceHttpClient.java
+++ b/capabilities-discovery/src/main/java/ai/wanaku/capabilities/sdk/discovery/DiscoveryServiceHttpClient.java
@@ -10,7 +10,6 @@ import java.net.http.HttpResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import ai.wanaku.capabilities.sdk.api.exceptions.WanakuException;
-import ai.wanaku.capabilities.sdk.api.types.discovery.ServiceState;
 import ai.wanaku.capabilities.sdk.api.types.providers.ServiceTarget;
 import ai.wanaku.capabilities.sdk.common.config.ServiceConfig;
 import ai.wanaku.capabilities.sdk.common.serializer.Serializer;
@@ -20,7 +19,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 
 /**
  * A client for interacting with the Wanaku Discovery and Registration API.
- * This class handles HTTP requests for service registration, deregistration, and state updates.
+ * This class handles HTTP requests for service registration and deregistration.
  */
 public class DiscoveryServiceHttpClient {
     private static final Logger LOG = LoggerFactory.getLogger(DiscoveryServiceHttpClient.class);
@@ -125,33 +124,5 @@ public class DiscoveryServiceHttpClient {
      */
     public HttpResponse<String> deregister(ServiceTarget serviceTarget) {
         return executeRequest("DELETE", "", serviceTarget);
-    }
-
-    /**
-     * Updates the state of a service with the Wanaku Discovery API.
-     *
-     * @param id The ID of the service whose state is to be updated.
-     * @param serviceState The new {@link ServiceState} of the service.
-     * @return The {@link HttpResponse} from the update state API call.
-     * @throws RuntimeException If JSON processing fails or an I/O error occurs during the request.
-     */
-    public HttpResponse<String> updateState(String id, ServiceState serviceState) {
-        try {
-            String jsonRequestBody = serializer.serialize(serviceState);
-            URI uri = URI.create(this.baseUrl + this.serviceBasePath + "/update/" + id);
-
-            HttpRequest request = withAuth(HttpRequest.newBuilder()
-                            .uri(uri)
-                            .header("Content-Type", MediaType.APPLICATION_JSON)
-                            .header("Accept", MediaType.WILDCARD))
-                    .POST(HttpRequest.BodyPublishers.ofString(jsonRequestBody))
-                    .build();
-
-            return httpClient.send(request, HttpResponse.BodyHandlers.ofString());
-        } catch (JsonProcessingException e) {
-            throw new InvalidResponseDataException(e);
-        } catch (InterruptedException | IOException e) {
-            throw new WanakuException(e);
-        }
     }
 }

--- a/capabilities-discovery/src/main/java/ai/wanaku/capabilities/sdk/discovery/ZeroDepRegistrationManager.java
+++ b/capabilities-discovery/src/main/java/ai/wanaku/capabilities/sdk/discovery/ZeroDepRegistrationManager.java
@@ -28,7 +28,7 @@ import com.fasterxml.jackson.core.type.TypeReference;
 /**
  * An implementation of {@link RegistrationManager} that handles the lifecycle registration
  * of a capability service with the Wanaku Discovery and Registration API.
- * This manager is responsible for registering, deregistering, and updating the state of a service,
+ * This manager is responsible for registering and deregistering a service,
  * and it uses {@link InstanceDataManager} to persist service-related data.
  */
 public class ZeroDepRegistrationManager implements RegistrationManager {

--- a/docs/client-registration-flow.md
+++ b/docs/client-registration-flow.md
@@ -38,7 +38,7 @@ The Wanaku registration system enables capability services (tools, resources, co
        │  │ PHASE 2: REGISTRATION                               │   │
        │  └─────────────────────────────────────────────────────┘   │
        │                                                            │
-       ├──── POST /api/v1/management/discovery/register ──────────► │
+       ├──── POST /api/v1/management/discovery ────────────────────► │
        │     Body: ServiceTarget (without ID)                       │
        │     Auth: Bearer {token}                                   │
        │                                                            │
@@ -53,7 +53,7 @@ The Wanaku registration system enables capability services (tools, resources, co
        │  │ PHASE 3: DEREGISTRATION                             │   │
        │  └─────────────────────────────────────────────────────┘   │
        │                                                            │
-       ├──── POST /api/v1/management/discovery/deregister ────────► │
+       ├──── DELETE /api/v1/management/discovery ─────────────────► │
        │     Body: ServiceTarget                                    │
        │                                                            │
        │ ◄──── 200 OK ────────────────────────────────────────────┤
@@ -86,13 +86,13 @@ sequenceDiagram
     Auth-->>Client: Access token + refresh token
 
     Note over Client: Registration Phase
-    Client->>Router: POST /api/v1/management/discovery/register
+    Client->>Router: POST /api/v1/management/discovery
     Router-->>Client: WanakuResponse<ServiceTarget> with assigned ID
     Client->>Storage: Persist service ID
     Client->>Client: Trigger onRegistration callbacks
 
     Note over Client: Deregistration Phase
-    Client->>Router: POST /api/v1/management/discovery/deregister
+    Client->>Router: DELETE /api/v1/management/discovery
     Router-->>Client: 200 OK
     Client->>Client: Trigger onDeregistration callbacks
 ```
@@ -103,8 +103,8 @@ All endpoints use the base path: `/api/v1/management/discovery`
 
 | Endpoint | Method | Request Body | Response | Description |
 |----------|--------|--------------|----------|-------------|
-| `/register` | POST | `ServiceTarget` | `WanakuResponse<ServiceTarget>` | Register service, receive assigned ID |
-| `/deregister` | POST | `ServiceTarget` | Status code | Remove service from registry |
+| `/` | POST | `ServiceTarget` | `WanakuResponse<ServiceTarget>` | Register service, receive assigned ID |
+| `/` | DELETE | `ServiceTarget` | Status code | Remove service from registry |
 
 ### Authentication
 

--- a/docs/client-registration-flow.md
+++ b/docs/client-registration-flow.md
@@ -50,14 +50,7 @@ The Wanaku registration system enables capability services (tools, resources, co
        ├──── Trigger onRegistration callback ─────────────────────► │
        │                                                            │
        │  ┌─────────────────────────────────────────────────────┐   │
-       │  │ PHASE 3: HEALTH UPDATES (As Needed)                 │   │
-       │  └─────────────────────────────────────────────────────┘   │
-       │                                                            │
-       ├──── POST /api/v1/management/discovery/update/{id} ───────► │
-       │     Body: ServiceState                                     │
-       │                                                            │
-       │  ┌─────────────────────────────────────────────────────┐   │
-       │  │ PHASE 4: DEREGISTRATION                             │   │
+       │  │ PHASE 3: DEREGISTRATION                             │   │
        │  └─────────────────────────────────────────────────────┘   │
        │                                                            │
        ├──── POST /api/v1/management/discovery/deregister ────────► │
@@ -98,13 +91,6 @@ sequenceDiagram
     Client->>Storage: Persist service ID
     Client->>Client: Trigger onRegistration callbacks
 
-    Note over Client: Health Updates (as needed)
-    alt On success
-        Client->>Router: POST /update/{id} with healthy state
-    else On failure
-        Client->>Router: POST /update/{id} with unhealthy state
-    end
-
     Note over Client: Deregistration Phase
     Client->>Router: POST /api/v1/management/discovery/deregister
     Router-->>Client: 200 OK
@@ -119,7 +105,6 @@ All endpoints use the base path: `/api/v1/management/discovery`
 |----------|--------|--------------|----------|-------------|
 | `/register` | POST | `ServiceTarget` | `WanakuResponse<ServiceTarget>` | Register service, receive assigned ID |
 | `/deregister` | POST | `ServiceTarget` | Status code | Remove service from registry |
-| `/update/{id}` | POST | `ServiceState` | Status code | Report health status |
 
 ### Authentication
 
@@ -310,19 +295,7 @@ This initiates:
 1. Initial registration attempt (with retries)
 2. Automatic ID persistence
 
-### Step 7: Report Health Status
-
-During operation, report your service health:
-
-```java
-// On successful operation
-registrationManager.lastAsSuccessful();
-
-// On failure
-registrationManager.lastAsFail("Database connection lost");
-```
-
-### Step 8: Deregister on Shutdown
+### Step 7: Deregister on Shutdown
 
 ```java
 // In shutdown hook or @PreDestroy
@@ -466,14 +439,6 @@ public class CapabilityService {
 
         registrationManager.addCallBack(new DiscoveryLogCallback());
         registrationManager.start();
-    }
-
-    public void reportSuccess() {
-        registrationManager.lastAsSuccessful();
-    }
-
-    public void reportFailure(String reason) {
-        registrationManager.lastAsFail(reason);
     }
 
     public void shutdown() {


### PR DESCRIPTION
## Summary

- Remove `lastAsFail(String)` and `lastAsSuccessful()` from `RegistrationManager` interface (both `@Deprecated(forRemoval=true)`, zero callers)
- Remove `ping(String)` and `updateState(String, ServiceState)` from `DiscoveryServiceHttpClient` (zero callers)
- Remove heartbeat, health update phases, and `/update/{id}` endpoint from client registration flow documentation
- Update `ZeroDepRegistrationManager` Javadoc to reflect actual behavior

## Test plan

- [x] `mvn clean install` passes (all modules compile, all tests pass)
- [ ] Downstream wanaku project may reference `lastAsFail`/`lastAsSuccessful` in docs — verify before SDK version bump

## Summary by Sourcery

Remove deprecated registration health/heartbeat capabilities from the SDK and align client and documentation with the simplified register/deregister lifecycle.

Enhancements:
- Simplify DiscoveryServiceHttpClient and ZeroDepRegistrationManager responsibilities to only handle registration and deregistration.
- Clean up the RegistrationManager interface by removing unused, deprecated health reporting methods.

Documentation:
- Update client registration flow documentation to remove heartbeat, health update phases, and associated endpoints, reflecting the current register/deregister-only behavior.

Tests:
- Remove tests covering the deprecated ping endpoint from DiscoveryServiceHttpClientTest.