### PR TITLE
feat: integration service template management API methods

### DIFF
--- a/capabilities-api/src/main/java/ai/wanaku/capabilities/sdk/api/types/ServiceTemplateDetail.java
+++ b/capabilities-api/src/main/java/ai/wanaku/capabilities/sdk/api/types/ServiceTemplateDetail.java
@@ -1,0 +1,147 @@
+package ai.wanaku.capabilities.sdk.api.types;
+
+import java.util.List;
+import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+/**
+ * Detailed information about a service template, as returned by the template retrieval endpoint.
+ * <p>
+ * In addition to the template metadata, the detail includes per-system information about
+ * the files that make up each service definition.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class ServiceTemplateDetail {
+    /**
+     * Default constructor for serialization frameworks.
+     */
+    public ServiceTemplateDetail() {}
+
+    private String id;
+    private String name;
+    private String icon;
+    private String description;
+    private List<ServiceTemplateSystem> services;
+
+    /**
+     * Gets the unique identifier of the template.
+     *
+     * @return the template ID
+     */
+    public String getId() {
+        return id;
+    }
+
+    /**
+     * Sets the unique identifier of the template.
+     *
+     * @param id the template ID to set
+     */
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    /**
+     * Gets the name of the template.
+     *
+     * @return the template name
+     */
+    public String getName() {
+        return name;
+    }
+
+    /**
+     * Sets the name of the template.
+     *
+     * @param name the template name to set
+     */
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    /**
+     * Gets the icon associated with the template.
+     *
+     * @return the template icon, or {@code null} if not provided
+     */
+    public String getIcon() {
+        return icon;
+    }
+
+    /**
+     * Sets the icon associated with the template.
+     *
+     * @param icon the template icon to set
+     */
+    public void setIcon(String icon) {
+        this.icon = icon;
+    }
+
+    /**
+     * Gets the description of the template.
+     *
+     * @return the template description, or {@code null} if not provided
+     */
+    public String getDescription() {
+        return description;
+    }
+
+    /**
+     * Sets the description of the template.
+     *
+     * @param description the template description to set
+     */
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    /**
+     * Gets the per-system information for the services included in the template.
+     *
+     * @return the service system information
+     */
+    public List<ServiceTemplateSystem> getServices() {
+        return services;
+    }
+
+    /**
+     * Sets the per-system information for the services included in the template.
+     *
+     * @param services the service system information to set
+     */
+    public void setServices(List<ServiceTemplateSystem> services) {
+        this.services = services;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        ServiceTemplateDetail that = (ServiceTemplateDetail) o;
+        return Objects.equals(id, that.id)
+                && Objects.equals(name, that.name)
+                && Objects.equals(icon, that.icon)
+                && Objects.equals(description, that.description)
+                && Objects.equals(services, that.services);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, name, icon, description, services);
+    }
+
+    @Override
+    public String toString() {
+        return "ServiceTemplateDetail{"
+                + "id='" + id + '\''
+                + ", name='" + name + '\''
+                + ", icon='" + icon + '\''
+                + ", description='" + description + '\''
+                + ", services=" + services
+                + '}';
+    }
+}

--- a/capabilities-api/src/main/java/ai/wanaku/capabilities/sdk/api/types/ServiceTemplateSummary.java
+++ b/capabilities-api/src/main/java/ai/wanaku/capabilities/sdk/api/types/ServiceTemplateSummary.java
@@ -1,0 +1,168 @@
+package ai.wanaku.capabilities.sdk.api.types;
+
+import java.util.List;
+import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+/**
+ * Summary information about a service template, as returned by the template listing endpoint.
+ * <p>
+ * Service templates are catalog packages with parameterized properties that can be
+ * instantiated into service catalogs by filling in parameter values.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class ServiceTemplateSummary {
+    /**
+     * Default constructor for serialization frameworks.
+     */
+    public ServiceTemplateSummary() {}
+
+    private String id;
+    private String name;
+    private String icon;
+    private String description;
+    private List<String> services;
+    private boolean hasProperties;
+
+    /**
+     * Gets the unique identifier of the template.
+     *
+     * @return the template ID
+     */
+    public String getId() {
+        return id;
+    }
+
+    /**
+     * Sets the unique identifier of the template.
+     *
+     * @param id the template ID to set
+     */
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    /**
+     * Gets the name of the template.
+     *
+     * @return the template name
+     */
+    public String getName() {
+        return name;
+    }
+
+    /**
+     * Sets the name of the template.
+     *
+     * @param name the template name to set
+     */
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    /**
+     * Gets the icon associated with the template.
+     *
+     * @return the template icon, or {@code null} if not provided
+     */
+    public String getIcon() {
+        return icon;
+    }
+
+    /**
+     * Sets the icon associated with the template.
+     *
+     * @param icon the template icon to set
+     */
+    public void setIcon(String icon) {
+        this.icon = icon;
+    }
+
+    /**
+     * Gets the description of the template.
+     *
+     * @return the template description, or {@code null} if not provided
+     */
+    public String getDescription() {
+        return description;
+    }
+
+    /**
+     * Sets the description of the template.
+     *
+     * @param description the template description to set
+     */
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    /**
+     * Gets the names of the services included in the template.
+     *
+     * @return the service names
+     */
+    public List<String> getServices() {
+        return services;
+    }
+
+    /**
+     * Sets the names of the services included in the template.
+     *
+     * @param services the service names to set
+     */
+    public void setServices(List<String> services) {
+        this.services = services;
+    }
+
+    /**
+     * Checks whether the template declares configurable properties.
+     *
+     * @return {@code true} if the template declares properties, {@code false} otherwise
+     */
+    public boolean isHasProperties() {
+        return hasProperties;
+    }
+
+    /**
+     * Sets whether the template declares configurable properties.
+     *
+     * @param hasProperties {@code true} if the template declares properties
+     */
+    public void setHasProperties(boolean hasProperties) {
+        this.hasProperties = hasProperties;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        ServiceTemplateSummary that = (ServiceTemplateSummary) o;
+        return hasProperties == that.hasProperties
+                && Objects.equals(id, that.id)
+                && Objects.equals(name, that.name)
+                && Objects.equals(icon, that.icon)
+                && Objects.equals(description, that.description)
+                && Objects.equals(services, that.services);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, name, icon, description, services, hasProperties);
+    }
+
+    @Override
+    public String toString() {
+        return "ServiceTemplateSummary{"
+                + "id='" + id + '\''
+                + ", name='" + name + '\''
+                + ", icon='" + icon + '\''
+                + ", description='" + description + '\''
+                + ", services=" + services
+                + ", hasProperties=" + hasProperties
+                + '}';
+    }
+}

--- a/capabilities-api/src/main/java/ai/wanaku/capabilities/sdk/api/types/ServiceTemplateSystem.java
+++ b/capabilities-api/src/main/java/ai/wanaku/capabilities/sdk/api/types/ServiceTemplateSystem.java
@@ -1,0 +1,144 @@
+package ai.wanaku.capabilities.sdk.api.types;
+
+import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+/**
+ * Per-system information within a service template, describing the files that make up
+ * the service definition for that system.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class ServiceTemplateSystem {
+    /**
+     * Default constructor for serialization frameworks.
+     */
+    public ServiceTemplateSystem() {}
+
+    private String name;
+    private String routesFile;
+    private String rulesFile;
+    private String dependenciesFile;
+    private String propertiesFile;
+
+    /**
+     * Gets the name of the system.
+     *
+     * @return the system name
+     */
+    public String getName() {
+        return name;
+    }
+
+    /**
+     * Sets the name of the system.
+     *
+     * @param name the system name to set
+     */
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    /**
+     * Gets the routes file for this system.
+     *
+     * @return the routes file, or {@code null} if not provided
+     */
+    public String getRoutesFile() {
+        return routesFile;
+    }
+
+    /**
+     * Sets the routes file for this system.
+     *
+     * @param routesFile the routes file to set
+     */
+    public void setRoutesFile(String routesFile) {
+        this.routesFile = routesFile;
+    }
+
+    /**
+     * Gets the rules file for this system.
+     *
+     * @return the rules file, or {@code null} if not provided
+     */
+    public String getRulesFile() {
+        return rulesFile;
+    }
+
+    /**
+     * Sets the rules file for this system.
+     *
+     * @param rulesFile the rules file to set
+     */
+    public void setRulesFile(String rulesFile) {
+        this.rulesFile = rulesFile;
+    }
+
+    /**
+     * Gets the dependencies file for this system.
+     *
+     * @return the dependencies file, or {@code null} if not provided
+     */
+    public String getDependenciesFile() {
+        return dependenciesFile;
+    }
+
+    /**
+     * Sets the dependencies file for this system.
+     *
+     * @param dependenciesFile the dependencies file to set
+     */
+    public void setDependenciesFile(String dependenciesFile) {
+        this.dependenciesFile = dependenciesFile;
+    }
+
+    /**
+     * Gets the properties file for this system.
+     *
+     * @return the properties file, or {@code null} if not provided
+     */
+    public String getPropertiesFile() {
+        return propertiesFile;
+    }
+
+    /**
+     * Sets the properties file for this system.
+     *
+     * @param propertiesFile the properties file to set
+     */
+    public void setPropertiesFile(String propertiesFile) {
+        this.propertiesFile = propertiesFile;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        ServiceTemplateSystem that = (ServiceTemplateSystem) o;
+        return Objects.equals(name, that.name)
+                && Objects.equals(routesFile, that.routesFile)
+                && Objects.equals(rulesFile, that.rulesFile)
+                && Objects.equals(dependenciesFile, that.dependenciesFile)
+                && Objects.equals(propertiesFile, that.propertiesFile);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name, routesFile, rulesFile, dependenciesFile, propertiesFile);
+    }
+
+    @Override
+    public String toString() {
+        return "ServiceTemplateSystem{"
+                + "name='" + name + '\''
+                + ", routesFile='" + routesFile + '\''
+                + ", rulesFile='" + rulesFile + '\''
+                + ", dependenciesFile='" + dependenciesFile + '\''
+                + ", propertiesFile='" + propertiesFile + '\''
+                + '}';
+    }
+}

--- a/capabilities-api/src/main/java/ai/wanaku/capabilities/sdk/api/types/io/TemplateInstantiationRequest.java
+++ b/capabilities-api/src/main/java/ai/wanaku/capabilities/sdk/api/types/io/TemplateInstantiationRequest.java
@@ -1,0 +1,145 @@
+package ai.wanaku.capabilities.sdk.api.types.io;
+
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Request payload for instantiating a service template.
+ * <p>
+ * Service templates are catalog packages with parameterized properties that can be
+ * instantiated into service catalogs by filling in parameter values. This request
+ * identifies the template to instantiate and provides the property values to apply.
+ */
+public final class TemplateInstantiationRequest {
+    /**
+     * Default constructor for serialization frameworks.
+     */
+    public TemplateInstantiationRequest() {}
+
+    /**
+     * Creates a new TemplateInstantiationRequest for the specified template.
+     *
+     * @param templateName the name of the template to instantiate
+     */
+    public TemplateInstantiationRequest(String templateName) {
+        this.templateName = templateName;
+    }
+
+    private String templateName;
+    private Map<String, String> properties;
+    private String serviceName;
+    private String serviceSystem;
+
+    /**
+     * Gets the name of the template to instantiate.
+     *
+     * @return the template name
+     */
+    public String getTemplateName() {
+        return templateName;
+    }
+
+    /**
+     * Sets the name of the template to instantiate.
+     *
+     * @param templateName the template name to set
+     */
+    public void setTemplateName(String templateName) {
+        this.templateName = templateName;
+    }
+
+    /**
+     * Gets the property values to fill in when instantiating the template.
+     *
+     * @return the property values, or {@code null} if not provided
+     */
+    public Map<String, String> getProperties() {
+        return properties;
+    }
+
+    /**
+     * Sets the property values to fill in when instantiating the template.
+     *
+     * @param properties the property values to set
+     */
+    public void setProperties(Map<String, String> properties) {
+        this.properties = properties;
+    }
+
+    /**
+     * Gets the name to assign to the instantiated service.
+     *
+     * @return the service name, or {@code null} if not provided
+     */
+    public String getServiceName() {
+        return serviceName;
+    }
+
+    /**
+     * Sets the name to assign to the instantiated service.
+     *
+     * @param serviceName the service name to set
+     */
+    public void setServiceName(String serviceName) {
+        this.serviceName = serviceName;
+    }
+
+    /**
+     * Gets the system to assign to the instantiated service.
+     *
+     * @return the service system, or {@code null} if not provided
+     */
+    public String getServiceSystem() {
+        return serviceSystem;
+    }
+
+    /**
+     * Sets the system to assign to the instantiated service.
+     *
+     * @param serviceSystem the service system to set
+     */
+    public void setServiceSystem(String serviceSystem) {
+        this.serviceSystem = serviceSystem;
+    }
+
+    /**
+     * Validates this request to ensure all required fields are present.
+     *
+     * @throws IllegalArgumentException if validation fails
+     */
+    public void validate() {
+        if (templateName == null || templateName.trim().isEmpty()) {
+            throw new IllegalArgumentException("Template name must not be null or empty");
+        }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        TemplateInstantiationRequest that = (TemplateInstantiationRequest) o;
+        return Objects.equals(templateName, that.templateName)
+                && Objects.equals(properties, that.properties)
+                && Objects.equals(serviceName, that.serviceName)
+                && Objects.equals(serviceSystem, that.serviceSystem);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(templateName, properties, serviceName, serviceSystem);
+    }
+
+    @Override
+    public String toString() {
+        return "TemplateInstantiationRequest{"
+                + "templateName='" + templateName + '\''
+                + ", properties=" + properties
+                + ", serviceName='" + serviceName + '\''
+                + ", serviceSystem='" + serviceSystem + '\''
+                + '}';
+    }
+}

--- a/capabilities-services-client/src/main/java/ai/wanaku/capabilities/sdk/services/ServicesHttpClient.java
+++ b/capabilities-services-client/src/main/java/ai/wanaku/capabilities/sdk/services/ServicesHttpClient.java
@@ -13,6 +13,7 @@ import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -25,11 +26,14 @@ import ai.wanaku.capabilities.sdk.api.types.DataStore;
 import ai.wanaku.capabilities.sdk.api.types.ForwardReference;
 import ai.wanaku.capabilities.sdk.api.types.Namespace;
 import ai.wanaku.capabilities.sdk.api.types.ResourceReference;
+import ai.wanaku.capabilities.sdk.api.types.ServiceTemplateDetail;
+import ai.wanaku.capabilities.sdk.api.types.ServiceTemplateSummary;
 import ai.wanaku.capabilities.sdk.api.types.ToolReference;
 import ai.wanaku.capabilities.sdk.api.types.WanakuResponse;
 import ai.wanaku.capabilities.sdk.api.types.execution.CodeExecutionEvent;
 import ai.wanaku.capabilities.sdk.api.types.execution.CodeExecutionRequest;
 import ai.wanaku.capabilities.sdk.api.types.execution.CodeExecutionResponse;
+import ai.wanaku.capabilities.sdk.api.types.io.TemplateInstantiationRequest;
 import ai.wanaku.capabilities.sdk.common.config.ServiceConfig;
 import ai.wanaku.capabilities.sdk.common.exceptions.WanakuWebException;
 import ai.wanaku.capabilities.sdk.common.serializer.Serializer;
@@ -40,7 +44,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 /**
  * A client for interacting with the Wanaku Services API.
- * This class handles HTTP requests for tools, resources, forwards, and namespaces operations.
+ * This class handles HTTP requests for tools, resources, forwards, namespaces, and service template operations.
  */
 public class ServicesHttpClient {
     private static final Logger LOG = LoggerFactory.getLogger(ServicesHttpClient.class);
@@ -470,6 +474,101 @@ public class ServicesHttpClient {
      */
     public WanakuResponse<DataStore> getServiceCatalog(String name) {
         return executeGet("/api/v1/service-catalog/download?name=" + encode(name), new TypeReference<>() {});
+    }
+
+    // ==================== Service Templates API Methods ====================
+
+    /**
+     * Lists all service templates.
+     *
+     * @return The response containing the list of template summaries.
+     * @throws WanakuException If an error occurs during the request.
+     */
+    public WanakuResponse<List<ServiceTemplateSummary>> listServiceTemplates() {
+        return listServiceTemplates(null);
+    }
+
+    /**
+     * Lists service templates, optionally filtered by a search term.
+     *
+     * @param search The search term to filter templates by name or description, or {@code null} to list all.
+     * @return The response containing the list of matching template summaries.
+     * @throws WanakuException If an error occurs during the request.
+     */
+    public WanakuResponse<List<ServiceTemplateSummary>> listServiceTemplates(String search) {
+        String path = "/api/v1/service-template/list";
+        if (search != null && !search.isBlank()) {
+            path = path + "?search=" + encode(search);
+        }
+        return executeGet(path, new TypeReference<>() {});
+    }
+
+    /**
+     * Gets a service template by name, including per-system details such as routes, rules,
+     * dependencies and properties files.
+     *
+     * @param name The name of the template to retrieve.
+     * @return The response containing the template detail.
+     * @throws WanakuException If an error occurs during the request.
+     */
+    public WanakuResponse<ServiceTemplateDetail> getServiceTemplate(String name) {
+        return executeGet("/api/v1/service-template/get?name=" + encode(name), new TypeReference<>() {});
+    }
+
+    /**
+     * Downloads a service template by name, returning the raw DataStore with Base64-encoded ZIP data.
+     *
+     * @param name The name of the template to download.
+     * @return The response containing the DataStore with the Base64-encoded ZIP.
+     * @throws WanakuException If an error occurs during the request.
+     */
+    public WanakuResponse<DataStore> downloadServiceTemplate(String name) {
+        return executeGet("/api/v1/service-template/download?name=" + encode(name), new TypeReference<>() {});
+    }
+
+    /**
+     * Deploys a service template ZIP package.
+     *
+     * @param dataStore The {@link DataStore} containing the Base64-encoded ZIP.
+     * @return The response containing the created data store entry.
+     * @throws WanakuException If an error occurs during the request.
+     */
+    public WanakuResponse<DataStore> deployServiceTemplate(DataStore dataStore) {
+        return executePost("/api/v1/service-template/deploy", dataStore, new TypeReference<>() {});
+    }
+
+    /**
+     * Removes a service template by name.
+     *
+     * @param name The name of the template to remove.
+     * @throws WanakuException If an error occurs during the request.
+     */
+    public void removeServiceTemplate(String name) {
+        executeDelete("/api/v1/service-template/remove?name=" + encode(name));
+    }
+
+    /**
+     * Gets the properties declared in a service template.
+     *
+     * @param name The name of the template.
+     * @return The response containing a map of system name to property key-value pairs.
+     * @throws WanakuException If an error occurs during the request.
+     */
+    public WanakuResponse<Map<String, Map<String, String>>> getServiceTemplateProperties(String name) {
+        return executeGet("/api/v1/service-template/properties?name=" + encode(name), new TypeReference<>() {});
+    }
+
+    /**
+     * Instantiates a service template by filling in property values, creating a new service catalog.
+     *
+     * @param request The {@link TemplateInstantiationRequest} containing the template name and property values.
+     * @return The response containing the newly created service catalog DataStore.
+     * @throws WanakuException If an error occurs during the request.
+     */
+    public WanakuResponse<DataStore> instantiateServiceTemplate(TemplateInstantiationRequest request) {
+        request.validate();
+
+        return executePost("/api/v1/service-template/instantiate", request, new TypeReference<>() {});
     }
 
     // ==================== Code Execution Engine API Methods ====================

--- a/capabilities-services-client/src/test/java/ai/wanaku/capabilities/sdk/services/ServicesHttpClientTest.java
+++ b/capabilities-services-client/src/test/java/ai/wanaku/capabilities/sdk/services/ServicesHttpClientTest.java
@@ -9,6 +9,7 @@ import ai.wanaku.capabilities.sdk.api.types.DataStore;
 import ai.wanaku.capabilities.sdk.api.types.ForwardReference;
 import ai.wanaku.capabilities.sdk.api.types.ResourceReference;
 import ai.wanaku.capabilities.sdk.api.types.ToolReference;
+import ai.wanaku.capabilities.sdk.api.types.io.TemplateInstantiationRequest;
 import ai.wanaku.capabilities.sdk.common.config.DefaultServiceConfig;
 import ai.wanaku.capabilities.sdk.common.serializer.JacksonSerializer;
 import com.sun.net.httpserver.HttpServer;
@@ -17,6 +18,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class ServicesHttpClientTest {
 
@@ -300,6 +302,99 @@ class ServicesHttpClientTest {
         assertEquals(1, requests.size());
         assertEquals("DELETE", requests.getFirst().method());
         assertEquals("/api/v1/data-store?name=my-store", requests.getFirst().path());
+    }
+
+    // ==================== Service Templates API Tests ====================
+
+    @Test
+    void listServiceTemplatesUsesGetAtListPath() {
+        client.listServiceTemplates();
+
+        assertEquals(1, requests.size());
+        assertEquals("GET", requests.getFirst().method());
+        assertEquals("/api/v1/service-template/list", requests.getFirst().path());
+    }
+
+    @Test
+    void listServiceTemplatesWithSearchUsesGetWithQueryParam() {
+        client.listServiceTemplates("kafka");
+
+        assertEquals(1, requests.size());
+        assertEquals("GET", requests.getFirst().method());
+        assertEquals(
+                "/api/v1/service-template/list?search=kafka",
+                requests.getFirst().path());
+    }
+
+    @Test
+    void getServiceTemplateUsesGetWithQueryParam() {
+        client.getServiceTemplate("my-template");
+
+        assertEquals(1, requests.size());
+        assertEquals("GET", requests.getFirst().method());
+        assertEquals(
+                "/api/v1/service-template/get?name=my-template",
+                requests.getFirst().path());
+    }
+
+    @Test
+    void downloadServiceTemplateUsesGetWithQueryParam() {
+        client.downloadServiceTemplate("my-template");
+
+        assertEquals(1, requests.size());
+        assertEquals("GET", requests.getFirst().method());
+        assertEquals(
+                "/api/v1/service-template/download?name=my-template",
+                requests.getFirst().path());
+    }
+
+    @Test
+    void deployServiceTemplateUsesPostAtDeployPath() {
+        client.deployServiceTemplate(new DataStore());
+
+        assertEquals(1, requests.size());
+        assertEquals("POST", requests.getFirst().method());
+        assertEquals("/api/v1/service-template/deploy", requests.getFirst().path());
+    }
+
+    @Test
+    void removeServiceTemplateUsesDeleteWithQueryParam() {
+        client.removeServiceTemplate("my-template");
+
+        assertEquals(1, requests.size());
+        assertEquals("DELETE", requests.getFirst().method());
+        assertEquals(
+                "/api/v1/service-template/remove?name=my-template",
+                requests.getFirst().path());
+    }
+
+    @Test
+    void getServiceTemplatePropertiesUsesGetWithQueryParam() {
+        client.getServiceTemplateProperties("my-template");
+
+        assertEquals(1, requests.size());
+        assertEquals("GET", requests.getFirst().method());
+        assertEquals(
+                "/api/v1/service-template/properties?name=my-template",
+                requests.getFirst().path());
+    }
+
+    @Test
+    void instantiateServiceTemplateUsesPostAtInstantiatePath() {
+        client.instantiateServiceTemplate(new TemplateInstantiationRequest("my-template"));
+
+        assertEquals(1, requests.size());
+        assertEquals("POST", requests.getFirst().method());
+        assertEquals("/api/v1/service-template/instantiate", requests.getFirst().path());
+    }
+
+    @Test
+    void instantiateServiceTemplateRejectsMissingTemplateName() {
+        TemplateInstantiationRequest request = new TemplateInstantiationRequest();
+
+        assertThrows(IllegalArgumentException.class, () -> client.instantiateServiceTemplate(request));
+
+        assertEquals(0, requests.size());
     }
 
     // ==================== No-Auth Tests ====================


### PR DESCRIPTION
Closes: #50

## Summary by Sourcery

Add client support for managing service templates via the Services API, including listing, retrieval, deployment, removal, property inspection, and instantiation into service catalogs.

New Features:
- Introduce service template management methods in ServicesHttpClient for listing, fetching, downloading, deploying, removing, inspecting properties, and instantiating templates.
- Add TemplateInstantiationRequest payload type to represent template instantiation parameters in the public API.

Tests:
- Extend ServicesHttpClientTest with coverage for all new service template API methods and their HTTP interactions.